### PR TITLE
New option axisLabelSize in print.ggpairs()

### DIFF
--- a/R/ggpairs.r
+++ b/R/ggpairs.r
@@ -635,6 +635,7 @@ print.ggpairs <- function(
   bottomHeightProportion = 0.1,
   spacingProportion = 0.03,
   showStrips = NULL,
+  axisLabelSize = 12,
   ...
 ) {
 
@@ -699,7 +700,7 @@ print.ggpairs <- function(
 
     # Left Side
     for(i in 1:numCol){
-      grid.text(plotObj$columnLabels[i],0,0.5,rot=90,just=c("centre","centre"), vp = vplayout(as.numeric(i) * 2 - 1 ,1))
+      grid.text(plotObj$columnLabels[i],0,0.5,rot=90,just=c("centre","centre"), vp = vplayout(as.numeric(i) * 2 - 1 ,1), gp = gpar(fontsize = axisLabelSize))
     }
 
     popViewport()# layout
@@ -725,7 +726,8 @@ print.ggpairs <- function(
         vp = vplayout(
           ifelse(showLabels, 2*numCol, 2*numCol - 1),
           ifelse(showLabels, 2*i, 2*i - 1)
-        )
+        ),
+        gp = gpar(fontsize = axisLabelSize)
       )
     }
 


### PR DESCRIPTION
This option is mapped directly to the `fontsize` graphical parameter in the `grid.text()` calls to write the bottom and left axis labels.
Otherwise, I have found no way of controlling that.

I think it would be better to read the parameters in the `theme` options.
So that this additional argument to `print.ggpairs` would be unnecessary.
But I am not sure how to do that safely.