### PR TITLE
changed geom_line to geom_path in gglyph

### DIFF
--- a/R/gglyph.r
+++ b/R/gglyph.r
@@ -191,7 +191,7 @@ rescale11 <- function(x, xlim=NULL) 2 * rescale01(x, xlim) - 1
 #' @export
 add_ref_lines <- function(data, color = "white", size = 1.5, ...){
   rl <- ref_lines(data)
-  geom_line(data = rl, color = color , size = size, ...)
+  geom_path(data = rl, color = color , size = size, ...)
 }
 
 #' Add reference boxes around each cell of the glyphmap.


### PR DESCRIPTION
@dicook 

Change of reference line when using polar.  Using geom_path to connect consecutive points, rather than sequential x-axis points with geom_line.

```{r}
load_all()
data(nasa)
nasaLate <- nasa[nasa$date >= as.POSIXct("1998-01-01"), ]

do_glyph <- function(...) {
  glyphs(nasaLate, "long", "day", "lat", "surftemp", height = 2.37, width = 2.38, ...)
}

do_gg <- function(dt) {
  ggplot2::ggplot(dt, ggplot2::aes(gx, gy, group = gid)) +
    add_ref_lines(dt, color = "red", size = 0.5) +
    add_ref_boxes(dt, color = "blue") +
    ggplot2::geom_path() +
    ggplot2::theme_bw() +
    ggplot2::labs(x = "", y = "") +
    ggplot2::xlim(-80, -60) + ggplot2::ylim(20,40)
}

## before change
do_gg(do_glyph())
do_gg(do_glyph(polar = TRUE))
```
![screenshot 2015-01-23 13 51 25](https://cloud.githubusercontent.com/assets/93231/5880546/5f898cf4-a307-11e4-9fe2-38b1e7ea81e7.png)
![screenshot 2015-01-23 13 51 36](https://cloud.githubusercontent.com/assets/93231/5880551/67b9b228-a307-11e4-8838-3347da2f3dd0.png)

```{r}
## after change
# load_all()
do_gg(do_glyph())
do_gg(do_glyph(polar = TRUE))
```
Same regular plot
![screenshot 2015-01-23 13 52 13](https://cloud.githubusercontent.com/assets/93231/5880562/7e474e10-a307-11e4-995c-e0de68c126e1.png)

Polar is now a circle
![screenshot 2015-01-23 13 52 26](https://cloud.githubusercontent.com/assets/93231/5880564/806f4c38-a307-11e4-86be-514593c205ed.png)
