### PR TITLE
Color censor marks by group

### DIFF
--- a/R/ggsurv.r
+++ b/R/ggsurv.r
@@ -198,7 +198,8 @@ ggsurv_m <- function(
 
   strataEqualNames <- unlist(strsplit(names(s$strata), '='))
   groups <- factor(
-    strataEqualNames[seq(2, 2 * strata, by = 2)]
+    strataEqualNames[seq(2, 2 * strata, by = 2)],
+    levels = strataEqualNames[seq(2, 2 * strata, by = 2)]
   )
 
   gr.name <-  strataEqualNames[1]
@@ -274,8 +275,7 @@ ggsurv_m <- function(
       )
     }
     else if(!identical(cens.col,surv.col)) {
-      warning ("Color scales for survival curves and censored points don't match.
-              Only one color scale can be used. Defaulting to surv.col")
+      warning ("Color scales for survival curves and censored points don't match.\nOnly one color scale can be used. Defaulting to surv.col")
       
       pl <- pl + geom_point(
         data = dat.cens,

--- a/R/ggsurv.r
+++ b/R/ggsurv.r
@@ -274,7 +274,7 @@ ggsurv_m <- function(
         col     = col
       )
     }
-    else if(!identical(cens.col,surv.col)) {
+    else if(!(identical(cens.col,surv.col) || is.null(cens.col))) {
       warning ("Color scales for survival curves and censored points don't match.\nOnly one color scale can be used. Defaulting to surv.col")
       
       pl <- pl + geom_point(

--- a/R/ggsurv.r
+++ b/R/ggsurv.r
@@ -274,8 +274,10 @@ ggsurv_m <- function(
         col     = col
       )
     }
-    else if(!(identical(cens.col,surv.col) || is.null(cens.col))) {
-      warning ("Color scales for survival curves and censored points don't match.\nOnly one color scale can be used. Defaulting to surv.col")
+    else {
+      if(!(identical(cens.col,surv.col) || is.null(cens.col))) {
+        warning ("Color scales for survival curves and censored points don't match.\nOnly one color scale can be used. Defaulting to surv.col")
+      }
       
       pl <- pl + geom_point(
         data = dat.cens,

--- a/R/ggsurv.r
+++ b/R/ggsurv.r
@@ -86,7 +86,7 @@ ggsurv <- function(
   CI         = 'def',
   plot.cens  = TRUE,
   surv.col   = 'gg.def',
-  cens.col   = 'red',
+  cens.col   = 'gg.def',
   lty.est    = 1,
   lty.ci     = 2,
   cens.shape = 3,
@@ -123,7 +123,7 @@ ggsurv_s <- function(
   CI         = 'def',
   plot.cens  = TRUE,
   surv.col   = 'gg.def',
-  cens.col   = 'red',
+  cens.col   = 'gg.def',
   lty.est    = 1,
   lty.ci     = 2,
   cens.shape = 3,
@@ -161,11 +161,13 @@ ggsurv_s <- function(
     if (length(dat.cens) == 0){
       stop('There are no censored observations')
     }
+    col <- ifelse(cens.col == 'gg.def', 'red', cens.col)
+    
     pl <- pl + geom_point(
       data    = dat.cens,
       mapping = aes(y = surv),
       shape   = cens.shape,
-      col     = cens.col
+      col     = col
     )
   }
 
@@ -182,7 +184,7 @@ ggsurv_m <- function(
   CI         = 'def',
   plot.cens  = TRUE,
   surv.col   = 'gg.def',
-  cens.col   = 'red',
+  cens.col   = 'gg.def',
   lty.est    = 1,
   lty.ci     = 2,
   cens.shape = 3,
@@ -225,7 +227,7 @@ ggsurv_m <- function(
     ggtitle(main)
 
   pl <- if(surv.col[1] != 'gg.def'){
-    scaleValues <- if (length(surv.col == 1)) {
+    scaleValues <- if (length(surv.col) == 1) {
       rep(surv.col, strata)
     } else{
       surv.col
@@ -262,12 +264,26 @@ ggsurv_m <- function(
     if (length(dat.cens) == 0) {
       stop ('There are no censored observations')
     }
-    pl <- pl + geom_point(
-      data    = dat.cens,
-      mapping = aes(y = surv),
-      shape   = cens.shape,
-      col     = cens.col
-    )
+    if (length(cens.col) == 1) {
+      col <- ifelse(cens.col == 'gg.def', 'red', cens.col)
+      pl <- pl + geom_point(
+        data    = dat.cens,
+        mapping = aes(y = surv),
+        shape   = cens.shape,
+        col     = col
+      )
+    }
+    else if(!identical(cens.col,surv.col)) {
+      warning ("Color scales for survival curves and censored points don't match.
+              Only one color scale can be used. Defaulting to surv.col")
+      
+      pl <- pl + geom_point(
+        data = dat.cens,
+        mapping = aes(y=surv, col = group),
+        shape = cens.shape,
+        show_guide = FALSE
+      )
+    }
   }
 
   if(identical(back.white, TRUE)) {


### PR DESCRIPTION
This commit allows users to color the censor marks using the same color scale used for the survival. See the example plot, below.

To achieve this, either `NULL` or the same value as `surv.col` is passed for `cens.col`

![surv](https://cloud.githubusercontent.com/assets/9858547/6549892/c4f80c66-c5f1-11e4-8d1e-636222b961cf.png)
