### PR TITLE
ggcorr improvements

### DIFF
--- a/R/ggcorr.R
+++ b/R/ggcorr.R
@@ -5,60 +5,89 @@ if(getRversion() >= "2.15.1") {
 
 #' ggcorr - Plot a correlation matrix with ggplot2
 #'
-#' Function for making a correlation plot starting from a data matrix, using ggplot2. The function is directly inspired by Tian Zheng and Yu-Sung Su's arm::corrplot function. Please visit \url{http://github.com/briatte/ggcorr} for the latest development and descriptions about ggcorr.
+#' Function for making a correlation matrix plot, using ggplot2.
+#' The function is directly inspired by Tian Zheng and Yu-Sung Su's
+#' \code{\link[arm]{corrplot}} function.
+#' Please visit \url{http://github.com/briatte/ggcorr} for the latest version
+#' of \code{ggcorr}.
 #'
 #' @export
-#' @param data a data matrix. Should contain numerical (continuous) data.
-#' @param method a character string giving a method for computing covariances in the presence of missing values. This must be (an abbreviation of) one of the strings \code{"everything"}, \code{"all.obs"}, \code{"complete.obs"}, \code{"na.or.complete"}, or \code{"pairwise.complete.obs"}.
-#' Defaults to \code{"pairwise"}.
+#' @param data a data frame or matrix containing numeric (continuous) data.
+#' @param method a vector of two character strings. The first value gives the
+#' method for computing covariances in the presence of missing values, and must
+#' be (an abbreviation of) one of \code{"everything"}, \code{"all.obs"},
+#' \code{"complete.obs"}, \code{"na.or.complete"} or
+#' \code{"pairwise.complete.obs"}. The second value gives the type of
+#' correlation coefficient to compute, and must be one of \code{"pearson"},
+#' \code{"kendall"} or \code{"spearman"}.
+#' See \code{\link[stats]{cor}} for details.
+#' Defaults to \code{c("pairwise", "pearson")}.
 #' @param cor_matrix the named correlation matrix to use for calculations.
+#' Defaults to the correlation matrix of \code{data} when \code{data} is
+#' supplied.
 #' @param palette if \code{nbreaks} has been set to something, a ColorBrewer
 #' palette to be used for correlation coefficients. Defaults to \code{"RdYlGn"}.
 #' @param name a character string for the legend that shows quintiles of
 #' correlation coefficients. Defaults to nothing.
 #' @param geom the geom object to use. Accepts either \code{tile} (the default)
 #' or \code{circle}, to plot proportionally scaled circles.
-#' @param max_size the maximum size for circles, as passed to \code{scale_size_identity}
-#' for proportional scaling. Defaults to \code{6}.
-#' @param min_size the maximum size for circles, as passed to \code{scale_size_identity}
-#' for proportional scaling. Defaults to \code{2}.
+#' @param max_size when \code{geom} has been set to \code{"circle"}, the maximum
+#' size of the circles, as passed to \code{scale_size_identity} for proportional
+#' scaling.
+#' Defaults to \code{6}.
+#' @param min_size when \code{geom} has been set to \code{"circle"}, the minimum
+#' size of the circles, as passed to \code{scale_size_identity} for proportional
+#' scaling.
+#' Defaults to \code{2}.
 #' @param label whether to add correlation coefficients as two-digit numbers
-#' over the plot. Defaults to \code{FALSE}.
-#' @param label_alpha whether to make the correlation coefficients transparent
-#' as they come close to 0. Defaults to \code{FALSE}.
-#' @param label_color color for the correlation coefficients. Defaults to \code{"black"}.
-#' @param label_round decimal rounding of the correlation coefficients.
+#' over the plot.
+#' Defaults to \code{FALSE}.
+#' @param label_alpha whether to make the correlation coefficients increasingly
+#' transparent as they come close to 0.
+#' Defaults to \code{FALSE}.
+#' @param label_color the color of the correlation coefficients.
+#' Defaults to \code{"black"}.
+#' @param label_round the decimal rounding of the correlation coefficients.
 #' Defaults to \code{1}.
-#' @param nbreaks number of breaks to apply to categorize the correlation
-#' coefficients. Defaults to \code{NULL} (continuous scaling).
-#' @param digits number of digits to show in the breaks of the correlation
-#' coefficients. Defaults to \code{2}.
-#' @param drop use the empirical range of correlation coefficients for their categorization,
-#' which is \emph{not} recommended (see 'Details'). Defaults to \code{FALSE}.
-#' @param low lower color of the gradient for continuous scaling of the correlation
-#' coefficients. Defaults to \code{d73027} (red).
-#' @param mid mid color of the gradient for continuous scaling of the correlation
-#' coefficients. Defaults to \code{d73027} (yellow).
-#' @param high upper color of the gradient for continuous scaling of the correlation
-#' coefficients. Defaults to \code{1a9850} (red).
-#' @param midpoint the midpoint value for continuous scaling of the correlation
-#' coefficients. Defaults to \code{0}.
-#' @param limits whether to bound the continuous color scaling of the correlation
-#' coefficients between -1 and +1. Defaults to \code{TRUE}.
-#' @param ... other arguments supplied to geom_text for the diagonal labels.
-#' Arguments pertaining to the title or other items can be achieved through ggplot2 methods.
+#' @param nbreaks the number of breaks to apply to the correlation coefficients.
+#' Defaults to \code{NULL} (no breaks, continuous scaling).
+#' @param digits the number of digits to show in the breaks of the correlation
+#' coefficients: see \code{\link[base]{cut}} for details.
+#' Defaults to \code{2}.
+#' @param drop whether to use the empirical range of the correlation
+#' coefficients in the color scale, which is \emph{not} recommended (see
+#' 'Details').
+#' Defaults to \code{FALSE}.
+#' @param low the lower color of the gradient for continuous scaling of the
+#' correlation coefficients.
+#' Defaults to \code{"#3B9AB2"} (blue).
+#' @param mid the midpoint color of the gradient for continuous scaling of the
+#' correlation coefficients.
+#' Defaults to \code{"#FFFFFF} (white).
+#' @param high the upper color of the gradient for continuous scaling of the
+#' correlation coefficients.
+#' Defaults to \code{"#F21A00"} (red).
+#' @param midpoint the midpoint value for continuous scaling of the
+#' correlation coefficients.
+#' Defaults to \code{0}.
+#' @param limits whether to bound the continuous color scaling of the
+#' correlation coefficients between -1 and +1.
+#' Defaults to \code{TRUE} (recommended).
+#' @param ... other arguments supplied to \code{\link[ggplot2]{geom_text}} for
+#' the diagonal labels.
 #' @details The \code{nbreaks} argument tries to break up the correlation
 #' coefficients into an ordinal color scale. Recommended values for the numbers
-#' of breaks are 3 to 11, as values above 11 are visually difficult to separate
-#' and are not supported by diverging ColorBrewer palettes.
+#' of breaks are \code{3} to \code{11}, as values above 11 are visually
+#' difficult to separate and are not supported by diverging ColorBrewer
+#' palettes.
 #'
 #' The breaks will range from -1 to +1, unless drop is set to \code{FALSE}, in
 #' which case the empirical range of the correlation coefficients is used. The
 #' latter is not recommended, as it creates a disbalance between the colors of
 #' negative and positive coefficients.
-#' @seealso \code{\link{cor}} and \code{\link[arm]{corrplot}}
-#' @author Francois Briatte \email{f.briatte@@gmail.com} with contributions from
-#' Amos B. Elberg \email{amos.elberg@@gmail.com} and Barret Schloerke \email{schloerke@@gmail.com}
+#' @seealso \code{\link[stats]{cor}} and \code{\link[arm]{corrplot}}
+#' @author Francois Briatte, with contributions from Amos B. Elberg and
+#' Barret Schloerke
 #' @importFrom reshape melt melt.data.frame melt.default
 #' @examples
 #' # Basketball statistics provided by Nathan Yau at Flowing Data.
@@ -91,11 +120,10 @@ if(getRversion() >= "2.15.1") {
 #'   data = NULL,
 #'   cor_matrix = cor(dt[, -1], use = "pairwise")
 #' )
-
 ggcorr <- function(
   data,
-  method = "pairwise",
-  cor_matrix = cor(data, use = method),
+  method = c("pairwise", "pearson"),
+  cor_matrix = NULL,
   palette = "RdYlGn",
   name = "",
   geom = "tile",
@@ -108,12 +136,33 @@ ggcorr <- function(
   nbreaks = NULL,
   digits = 2,
   drop = FALSE,
-  low = "#3B9AB2",  # (blue) replaces "#d73027" (red)
-  mid = "#FFFFFF",  # (yellow) replaces "#ffffbf" (light yellow)
-  high = "#F21A00", # (red) replaces "#1a9850" (green)
+  low = "#3B9AB2",  # (blue)  replaces "#d73027" (red)
+  mid = "#FFFFFF",  # (white) replaces "#ffffbf" (light yellow)
+  high = "#F21A00", # (red)   replaces "#1a9850" (green)
   midpoint = 0,
   limits = TRUE,
   ...) {
+
+  # for backwards compatibility
+  if (length(method) == 1) {
+    method = c(method, "pearson")
+  }
+
+  if (is.null(cor_matrix)) {
+    cor_matrix = cor(data, use = method[1], method = method[2])
+  }
+
+  if (!is.null(data) && "data.frame" %in% class(data)) {
+    r = names(data)[ !sapply(data, is.numeric) ]
+  } else if (!is.null(data) && !is.null(colnames(data))) {
+    r = colnames(data)[ !apply(data, 2, is.numeric) ]
+  } else {
+    r = which(!apply(data, 2, is.numeric))
+  }
+
+  if (length(r) > 0) {
+    stop(paste("column(s)", paste0(r, collapse = ", "), "are not numeric"))
+  }
 
   M = cor_matrix
 
@@ -178,7 +227,7 @@ ggcorr <- function(
   if (geom == "circle") {
 
     p = p +
-      geom_point(aes(size = num + 0.25), color = "grey50") +
+      #geom_point(aes(size = num + 0.25), color = "grey50") +
       geom_point(aes(size = num, color = value))
 
     if (is.null(nbreaks) && limits) {

--- a/R/ggcorr.R
+++ b/R/ggcorr.R
@@ -84,12 +84,12 @@ if(getRversion() >= "2.15.1") {
 #'   nbreaks = 6,
 #'   angle = -45,
 #'   palette = "PuOr" # colorblind safe, photocopy-able
-#' ) + ggplot2::labs(title = "Correlation Matrix")
+#' )
 #'
 #' # Supply your own correlation matrix
 #' ggcorr(
 #'   data = NULL,
-#'   cor_matrix = cor(dt[,-1], use = "pairwise")
+#'   cor_matrix = cor(dt[, -1], use = "pairwise")
 #' )
 
 ggcorr <- function(
@@ -153,7 +153,8 @@ ggcorr <- function(
   if(is.null(midpoint)) {
 
     midpoint = median(M$value, na.rm = TRUE)
-    message("Color gradient midpoint set at median correlation to ", round(midpoint, 2))
+    message(paste("Color gradient midpoint set at median correlation to",
+                  round(midpoint, 2)))
 
   }
 

--- a/R/ggcorr.R
+++ b/R/ggcorr.R
@@ -26,10 +26,12 @@ if (getRversion() >= "2.15.1") {
 #' @param cor_matrix the named correlation matrix to use for calculations.
 #' Defaults to the correlation matrix of \code{data} when \code{data} is
 #' supplied.
-#' @param palette if \code{nbreaks} has been set to something, a ColorBrewer
-#' palette to be used for correlation coefficients. Defaults to \code{"RdYlGn"}.
-#' @param name a character string for the legend that shows quintiles of
-#' correlation coefficients. Defaults to nothing.
+#' @param palette if \code{nbreaks} is used, a ColorBrewer palette to use
+#' instead of the colors specified by \code{low}, \code{mid} and \code{high}.
+#' Defaults to \code{NULL}.
+#' @param name a character string for the legend that shows the colors of the
+#' correlation coefficients.
+#' Defaults to \code{""} (no legend name).
 #' @param geom the geom object to use. Accepts either \code{"tile"},
 #' \code{"circle"}, \code{"text"} or \code{"blank"}.
 #' @param min_size when \code{geom} has been set to \code{"circle"}, the minimum
@@ -54,10 +56,6 @@ if (getRversion() >= "2.15.1") {
 #' @param digits the number of digits to show in the breaks of the correlation
 #' coefficients: see \code{\link[base]{cut}} for details.
 #' Defaults to \code{2}.
-#' @param drop whether to use the empirical range of the correlation
-#' coefficients in the color scale, which is \emph{not} recommended (see
-#' 'Details').
-#' Defaults to \code{FALSE}.
 #' @param low the lower color of the gradient for continuous scaling of the
 #' correlation coefficients.
 #' Defaults to \code{"#3B9AB2"} (blue).
@@ -70,13 +68,19 @@ if (getRversion() >= "2.15.1") {
 #' @param midpoint the midpoint value for continuous scaling of the
 #' correlation coefficients.
 #' Defaults to \code{0}.
-#' @param limits whether to bound the continuous color scaling of the
-#' correlation coefficients between -1 and +1.
+#' @param limits whether to bound the color scaling of the correlation
+#' coefficients between -1 and +1.
 #' Defaults to \code{TRUE} (recommended).
+#' @param drop whether to use the empirical range of the correlation
+#' coefficients in the color scale, which is \emph{not} recommended (see
+#' 'Details').
+#' Defaults to \code{FALSE}.
 #' @param legend.position where to put the legend of the correlation
 #' coefficients: see \code{\link[ggplot2]{theme}} for details.
+#' Defaults to \code{"bottom"}.
 #' @param legend.size the size of the legend title and labels, in points: see
 #' \code{\link[ggplot2]{theme}} for details.
+#' Defaults to \code{9}.
 #' @param ... other arguments supplied to \code{\link[ggplot2]{geom_text}} for
 #' the diagonal labels.
 #' @details The \code{nbreaks} argument tries to break up the correlation
@@ -148,10 +152,6 @@ ggcorr <- function(
   legend.position = "right",
   legend.size = 9,
   ...) {
-
-  # -- packages ----------------------------------------------------------------
-
-  # require_pkgs("reshape2")
 
   # -- check geom argument -----------------------------------------------------
 

--- a/R/ggcorr.R
+++ b/R/ggcorr.R
@@ -61,7 +61,7 @@ if (getRversion() >= "2.15.1") {
 #' Defaults to \code{"#3B9AB2"} (blue).
 #' @param mid the midpoint color of the gradient for continuous scaling of the
 #' correlation coefficients.
-#' Defaults to \code{"#EEEEEE} (very light grey).
+#' Defaults to \code{"#EEEEEE"} (very light grey).
 #' @param high the upper color of the gradient for continuous scaling of the
 #' correlation coefficients.
 #' Defaults to \code{"#F21A00"} (red).
@@ -143,9 +143,9 @@ ggcorr <- function(
   label_color = "black",
   label_round = 1,
   drop = FALSE,
-  low = "#3B9AB2",  # (blue)  replaces "#d73027" (red)
+  low = "#3B9AB2",  # (blue) replaces "#d73027" (red)
   mid = "#EEEEEE",  # (grey) replaces "#ffffbf" (light yellow)
-  high = "#F21A00", # (red)   replaces "#1a9850" (green)
+  high = "#F21A00", # (red)  replaces "#1a9850" (green)
   midpoint = 0,
   palette = NULL,
   limits = TRUE,

--- a/tests/testthat/test-ggcorr.R
+++ b/tests/testthat/test-ggcorr.R
@@ -5,8 +5,6 @@ context("ggcorr")
 
 data(flea)
 
-
-
 test_that("examples", {
   # Default output.
   p <- ggcorr(flea[, -1])
@@ -26,11 +24,11 @@ test_that("examples", {
     max_size = 6,
     size = 3,
     hjust = 0.75,
+    nbreaks = 6,
     angle = -45,
     palette = "PuOr" # colorblind safe, photocopy-able
   )
   expect_equal(length(p$layers), 3)
-
 
   p <- ggcorr(flea[, -1],
          label = TRUE,
@@ -38,6 +36,16 @@ test_that("examples", {
   expect_equal(length(p$layers), 3)
 })
 
+test_that("null midpoint", {
+  expect_message(ggcorr(flea[, -1], midpoint = NULL), "Color gradient")
+})
+
+test_that("further options", {
+  ggcorr(flea[, -1], geom = "circle")
+  ggcorr(flea[, -1], geom = "circle", limits = FALSE)
+  ggcorr(flea[, -1], geom = "tile", nbreaks = 3)
+  ggcorr(flea[, -1], geom = "tile", limits = FALSE)
+})
 
 test_that("data.matrix", {
   p <- ggcorr(data.matrix(flea[, -1]))

--- a/tests/testthat/test-ggcorr.R
+++ b/tests/testthat/test-ggcorr.R
@@ -6,6 +6,7 @@ context("ggcorr")
 data(flea)
 
 test_that("examples", {
+
   # Default output.
   p <- ggcorr(flea[, -1])
   expect_equal(length(p$layers), 2)
@@ -34,6 +35,21 @@ test_that("examples", {
          label = TRUE,
          name = "")
   expect_equal(length(p$layers), 3)
+
+  # test other combinations of geoms + color scales
+  ggcorr(flea[, -1], nbreaks = 4, palette = "PuOr")
+  ggcorr(flea[, -1], nbreaks = 4, geom = "circle")
+  ggcorr(flea[, -1], geom = "text")
+  ggcorr(flea[, -1], geom = "text", limits = FALSE)
+  ggcorr(flea[, -1], nbreaks = 4, geom = "text")
+  ggcorr(flea[, -1], nbreaks = 4, palette = "PuOr", geom = "text")
+
+  ggcorr(flea[, -1], label = TRUE, label_alpha = 0.5)
+
+})
+
+test_that("non-numeric data", {
+  expect_warning(ggcorr(flea), "not numeric")
 })
 
 test_that("null midpoint", {
@@ -56,4 +72,13 @@ test_that("data.matrix", {
 test_that("cor_matrix", {
   p <- ggcorr(data = NULL, cor_matrix = cor(flea[, -1], use = "pairwise"))
   expect_equal(length(p$layers), 2)
+})
+
+test_that("other geoms", {
+  expect_error(ggcorr(flea[, -1], geom = "hexbin"), "incorrect geom")
+  ggcorr(flea[, -1], geom = "blank")
+})
+
+test_that("backwards compatibility", {
+  ggcorr(flea[, -1], method = "everything")
 })


### PR DESCRIPTION
- reworked code that creates less objects
- changed the default colors to something more sensible
- added possibility use Spearman or Kendall correlation coefficients
- added `geom = "text"` method to plot correlation coefficients as just text
- added controls over legend size and position

The code is now cleaner, except for the hack at lines 203-204, where I need to create a variable that must not have the same name as any variable in the data.frame. I'm not sure I did that correctly: I'm not sure, for instance, that I need to declare the hack-y variable in `globalVariables` at the top of the script.

Also, I'm using `reshape::melt`, but could be using `reshape2::melt`. I don't really know why `GGally` imports `reshape` instead of `reshape2` (although I'm sure there's a good reason, since `reshape` has more functionalities than `reshape2` in my experience).