### PR TITLE
handle issue #93

### DIFF
--- a/tests/testthat/test-ggnet.R
+++ b/tests/testthat/test-ggnet.R
@@ -1,6 +1,10 @@
 
 context("ggnet")
 
+if ("package:igraph" %in% search()) {
+  detach("package:igraph")
+}
+
 require(network      , quietly = TRUE) # network objects
 require(sna          , quietly = TRUE) # placement and centrality
 

--- a/tests/testthat/test-ggnet2.R
+++ b/tests/testthat/test-ggnet2.R
@@ -1,6 +1,10 @@
 
 context("ggnet2")
 
+if ("package:igraph" %in% search()) {
+  detach("package:igraph")
+}
+
 require(network      , quietly = TRUE) # network objects
 require(sna          , quietly = TRUE) # placement and centrality
 

--- a/tests/testthat/test-ggnet2.R
+++ b/tests/testthat/test-ggnet2.R
@@ -139,7 +139,7 @@ test_that("examples", {
   
   # test shape.palette
   ggnet2(n, shape = "phono", shape.palette = c("vowel" = 15, "consonant" = 19))
-  ggnet2(n, shape = factor(1:10))
+  expect_warning(ggnet2(n, shape = factor(1:10)), "discrete values")
   expect_error(ggnet2(n, shape = "phono", shape.palette = c("vowel" = 1)), "no shape.palette value")
   
   # test size.palette


### PR DESCRIPTION
- Solves the second part of issue #93.
- Works around the first part of issue #93.

The problem remains that I do not know how to avoid conflicts with `igraph`. If the user loads `igraph` after loading `ggnet` / `ggnet2` / `GGally`, then it's easy to get this error:

```
> ggnet2(n, size = "degree")
 Error in is.bipartite(x) : Not a graph object 
5 stop("Not a graph object") 
4 is.bipartite(x) 
3 as.edgelist.sna(dat) 
2 sna::degree(net, gmode = is_dir, cmode = ifelse(x == "degree", 
    "freeman", x)) at ggnet2.R#484
1 ggnet2(n, size = "degree") 
```