### PR TITLE
arrow.gap option + coverage tests

### DIFF
--- a/R/ggnet.R
+++ b/R/ggnet.R
@@ -126,8 +126,8 @@ if (getRversion() >= "2.15.1") {
 #' \code{\link[sna]{gplot}} in the \code{\link[sna]{sna}} package, and
 #' \code{\link[network]{plot.network}} in the \code{\link[network]{network}}
 #' package
-#' @author Moritz Marbach and Francois Briatte, with contributions from
-#' Heike Hoffmann and Ming-Yu Liu
+#' @author Moritz Marbach and Francois Briatte, with help from Heike Hoffmann,
+#' Pedro Jordano and Ming-Yu Liu
 #' @details The degree centrality measures that can be produced through the
 #' \code{weight} argument will take the directedness of the network into account,
 #' but will be unweighted. To compute weighted network measures, see the

--- a/R/ggnet.R
+++ b/R/ggnet.R
@@ -702,6 +702,7 @@ ggnet <- function(
       geom_text(
         label = l,
         size  = label.size,
+        show.legend = FALSE, # required by ggplot2 >= 1.0.1.9003
         ...
       )
 

--- a/R/ggnet.R
+++ b/R/ggnet.R
@@ -586,9 +586,12 @@ ggnet <- function(
   if (nrow(edges) > 0) {
 
     if (arrow.gap > 0) {
+
+      arrow.gap = with(edges, arrow.gap / sqrt((X2 - X1)^2 + (Y2 - Y1)^2))
       edges = transform(edges,
                         X2 = X1 + (1 - arrow.gap) * (X2 - X1),
                         Y2 = Y1 + (1 - arrow.gap) * (Y2 - Y1))
+
     }
 
     p = p +

--- a/R/ggnet.R
+++ b/R/ggnet.R
@@ -86,8 +86,8 @@ if (getRversion() >= "2.15.1") {
 #' Defaults to \code{0} (no arrows).
 #' @param arrow.gap a setting aimed at improving the display of edge arrows by
 #' plotting slightly shorter edges. Accepts any value between \code{0} and
-#' \code{1}, where values close to \code{0.95} will generally achieve good
-#' results if the size of the nodes is small.
+#' \code{1}, where a value of \code{0.05} will generally achieve good results
+#' when the size of the nodes is reasonably small.
 #' Defaults to \code{0} (no shortening).
 #' @param arrow.type the type of the arrows for directed network edges. See
 #' \code{\link[grid]{arrow}} for details.
@@ -160,7 +160,7 @@ if (getRversion() >= "2.15.1") {
 #'   ggnet(n, node.group = g, node.color = p, label = TRUE, color = "white")
 #'
 #'   # edge arrows on a directed network
-#'   ggnet(network(m, directed = TRUE), arrow.gap = 0.9, arrow.size = 10)
+#'   ggnet(network(m, directed = TRUE), arrow.gap = 0.05, arrow.size = 10)
 #'
 #' }
 ggnet <- function(
@@ -595,19 +595,13 @@ ggnet <- function(
       x.length = with(edges, abs(X2 - X1))
       y.length = with(edges, abs(Y2 - Y1))
 
-      k = 10
-      x.length = cut_interval(x.length, k, labels = 1:k)
-      y.length = cut_interval(y.length, k, labels = 1:k)
-
-      arrow.gap = rev(seq(arrow.gap - 0.05, arrow.gap, length.out = k))
-      x.length = arrow.gap[ x.length ]
-      y.length = arrow.gap[ y.length ]
+      arrow.gap = with(edges, arrow.gap / sqrt(x.length ^ 2 + y.length ^ 2))
 
       edges = transform(edges,
-                        X2 = X1 + x.length * (X2 - X1),
-                        Y2 = Y1 + y.length * (Y2 - Y1),
-                        X1 = X2 + x.length * (X1 - X2),
-                        Y1 = Y2 + y.length * (Y1 - Y2))
+                        X1 = X1 + arrow.gap * x.length,
+                        Y1 = Y1 + arrow.gap * y.length,
+                        X2 = X1 + (1 - arrow.gap) * x.length,
+                        Y2 = Y1 + (1 - arrow.gap) * y.length)
 
     }
 

--- a/R/ggnet.R
+++ b/R/ggnet.R
@@ -84,6 +84,10 @@ if(getRversion() >= "2.15.1") {
 #' @param arrow.size the size of the arrows for directed network edges, in
 #' points. See \code{\link[grid]{arrow}} for details.
 #' Defaults to \code{0} (no arrows).
+#' @param arrow.gap the size of the gap to leave between the end of the edges
+#' and the receiving nodes of a directed network, as a fraction of edge length.
+#' This setting aims at improving the display of edge arrows.
+#' Defaults to \code{0} (no gap).
 #' @param arrow.type the type of the arrows for directed network edges. See
 #' \code{\link[grid]{arrow}} for details.
 #' Defaults to \code{"closed"}.
@@ -177,6 +181,7 @@ ggnet <- function(
   segment.label    = NULL,
   segment.size     = 0.25,
   arrow.size       = 0,
+  arrow.gap        = 0,
   arrow.type       = "closed",
   label            = FALSE,
   label.nodes      = label,
@@ -331,6 +336,13 @@ ggnet <- function(
     arrow.size = 0
   }
 
+  if (!is.numeric(arrow.gap) || arrow.gap < 0) {
+    stop("incorrect arrow.gap value")
+  } else if (arrow.gap > 0 & is_dir == "graph") {
+    warning("network is undirected; arrow.gap ignored")
+    arrow.gap = 0
+  }
+
   if (network::is.hyper(net)) {
     stop("ggnet cannot plot hyper graphs")
   }
@@ -363,11 +375,11 @@ ggnet <- function(
 
     # prevent namespace conflict with igraph
     if ("package:igraph" %in% search()) {
-      
+
       y = ifelse(is_dir == "digraph", "directed", "undirected")
       z = c("indegree" = "in", "outdegree" = "out", "degree" = "all", "freeman" = "all")[ x ]
       data$weight = igraph::degree(igraph::graph.adjacency(as.matrix(net), mode = y), mode = z)
-      
+
     } else {
       data$weight = sna::degree(net, gmode = is_dir, cmode = ifelse(x == "degree", "freeman", x))
     }
@@ -546,6 +558,9 @@ ggnet <- function(
 
   }
 
+  xy$x = scale(xy$x, min(xy$x), diff(range(xy$x)))
+  xy$y = scale(xy$y, min(xy$y), diff(range(xy$y)))
+
   data = cbind(data, xy)
 
   # -- edge list ---------------------------------------------------------------
@@ -569,6 +584,12 @@ ggnet <- function(
   p = ggplot(data, aes(x = x, y = y))
 
   if (nrow(edges) > 0) {
+
+    if (arrow.gap > 0) {
+      edges = transform(edges,
+                        X2 = X1 + (1 - arrow.gap) * (X2 - X1),
+                        Y2 = Y1 + (1 - arrow.gap) * (Y2 - Y1))
+    }
 
     p = p +
       geom_segment(

--- a/R/ggnet.R
+++ b/R/ggnet.R
@@ -126,7 +126,8 @@ if (getRversion() >= "2.15.1") {
 #' \code{\link[sna]{gplot}} in the \code{\link[sna]{sna}} package, and
 #' \code{\link[network]{plot.network}} in the \code{\link[network]{network}}
 #' package
-#' @author Moritz Marbach and Francois Briatte
+#' @author Moritz Marbach and Francois Briatte, with contributions from
+#' Heike Hoffmann and Ming-Yu Liu
 #' @details The degree centrality measures that can be produced through the
 #' \code{weight} argument will take the directedness of the network into account,
 #' but will be unweighted. To compute weighted network measures, see the

--- a/R/ggnet2.R
+++ b/R/ggnet2.R
@@ -1037,9 +1037,9 @@ ggnet2 <- function(
 
     label.color = set_node(label.color, "label.color", mode = FALSE)
 
-    # if (!is_col(label.color)) {
-    #   stop("incorrect label.color value")
-    # }
+    if (!is_col(label.color)) {
+      stop("incorrect label.color value")
+    }
 
     label.size = set_node(label.size, "label.size", mode = FALSE)
 

--- a/R/ggnet2.R
+++ b/R/ggnet2.R
@@ -1037,9 +1037,9 @@ ggnet2 <- function(
 
     label.color = set_node(label.color, "label.color", mode = FALSE)
 
-    if (!is_col(label.color)) {
-      stop("incorrect label.color value")
-    }
+    # if (!is_col(label.color)) {
+    #   stop("incorrect label.color value")
+    # }
 
     label.size = set_node(label.size, "label.size", mode = FALSE)
 

--- a/R/ggnet2.R
+++ b/R/ggnet2.R
@@ -1,4 +1,4 @@
-if(getRversion() >= "2.15.1") {
+if (getRversion() >= "2.15.1") {
   utils::globalVariables(c("X1", "X2", "Y1", "Y2", "midX", "midY"))
 }
 
@@ -165,10 +165,11 @@ if(getRversion() >= "2.15.1") {
 #' @param arrow.size the size of the arrows for directed network edges, in
 #' points. See \code{\link[grid]{arrow}} for details.
 #' Defaults to \code{0} (no arrows).
-#' @param arrow.gap the size of the gap to leave between the end of the edges
-#' and the receiving nodes of a directed network, as a fraction of edge length.
-#' This setting aims at improving the display of edge arrows.
-#' Defaults to \code{0} (no gap).
+#' @param arrow.gap a setting aimed at improving the display of edge arrows by
+#' plotting slightly shorter edges. Accepts any value between \code{0} and
+#' \code{1}, where values close to \code{0.95} will generally achieve good
+#' results if the size of the nodes is small.
+#' Defaults to \code{0} (no shortening).
 #' @param arrow.type the type of the arrows for directed network edges. See
 #' \code{\link[grid]{arrow}} for details.
 #' Defaults to \code{"closed"}.
@@ -236,6 +237,9 @@ if(getRversion() >= "2.15.1") {
 #'   # random weights
 #'   n %e% "weight" <- sample(1:3, network.edgecount(n), replace = TRUE)
 #'   ggnet2(n, edge.size = "weight", edge.label = "weight")
+#'
+#'   # edge arrows on a directed network
+#'   ggnet2(network(m, directed = TRUE), arrow.gap = 0.9, arrow.size = 10)
 #'
 #'   # Padgett's Florentine wedding data
 #'   data(flo, package = "network")
@@ -420,7 +424,7 @@ ggnet2 <- function(
     arrow.size = 0
   }
 
-  if (!is.numeric(arrow.gap) || arrow.gap < 0) {
+  if (!is.numeric(arrow.gap) || arrow.gap < 0 || arrow.gap > 1) {
     stop("incorrect arrow.gap value")
   } else if (arrow.gap > 0 & is_dir == "graph") {
     warning("network is undirected; arrow.gap ignored")
@@ -854,10 +858,22 @@ ggnet2 <- function(
 
     if (arrow.gap > 0) {
 
-      arrow.gap = with(edges, arrow.gap / sqrt((X2 - X1)^2 + (Y2 - Y1)^2))
+      x.length = with(edges, abs(X2 - X1))
+      y.length = with(edges, abs(Y2 - Y1))
+
+      k = 10
+      x.length = cut_interval(x.length, k, labels = 1:k)
+      y.length = cut_interval(y.length, k, labels = 1:k)
+
+      arrow.gap = rev(seq(arrow.gap - 0.05, arrow.gap, length.out = k))
+      x.length = arrow.gap[ x.length ]
+      y.length = arrow.gap[ y.length ]
+
       edges = transform(edges,
-                        X2 = X1 + (1 - arrow.gap) * (X2 - X1),
-                        Y2 = Y1 + (1 - arrow.gap) * (Y2 - Y1))
+                        X2 = X1 + x.length * (X2 - X1),
+                        Y2 = Y1 + y.length * (Y2 - Y1),
+                        X1 = X2 + x.length * (X1 - X2),
+                        Y1 = Y2 + y.length * (Y1 - Y2))
 
     }
 

--- a/R/ggnet2.R
+++ b/R/ggnet2.R
@@ -184,7 +184,8 @@ if (getRversion() >= "2.15.1") {
 #' \code{\link[sna]{gplot}} in the \code{\link[sna]{sna}} package, and
 #' \code{\link[network]{plot.network}} in the \code{\link[network]{network}}
 #' package
-#' @author Moritz Marbach and Francois Briatte
+#' @author Moritz Marbach and Francois Briatte, with contributions from
+#' Heike Hoffmann and Ming-Yu Liu
 #' @details The degree centrality measures that can be produced through the
 #' \code{size} argument will take the directedness of the network into account,
 #' but will be unweighted. To compute weighted network measures, see the

--- a/R/ggnet2.R
+++ b/R/ggnet2.R
@@ -184,8 +184,8 @@ if (getRversion() >= "2.15.1") {
 #' \code{\link[sna]{gplot}} in the \code{\link[sna]{sna}} package, and
 #' \code{\link[network]{plot.network}} in the \code{\link[network]{network}}
 #' package
-#' @author Moritz Marbach and Francois Briatte, with contributions from
-#' Heike Hoffmann and Ming-Yu Liu
+#' @author Moritz Marbach and Francois Briatte, with help from Heike Hoffmann,
+#' Pedro Jordano and Ming-Yu Liu
 #' @details The degree centrality measures that can be produced through the
 #' \code{size} argument will take the directedness of the network into account,
 #' but will be unweighted. To compute weighted network measures, see the

--- a/R/ggnet2.R
+++ b/R/ggnet2.R
@@ -853,9 +853,12 @@ ggnet2 <- function(
   if (nrow(edges) > 0) {
 
     if (arrow.gap > 0) {
+
+      arrow.gap = with(edges, arrow.gap / sqrt((X2 - X1)^2 + (Y2 - Y1)^2))
       edges = transform(edges,
                         X2 = X1 + (1 - arrow.gap) * (X2 - X1),
                         Y2 = Y1 + (1 - arrow.gap) * (Y2 - Y1))
+
     }
 
     p = p +

--- a/R/ggnet2.R
+++ b/R/ggnet2.R
@@ -167,8 +167,8 @@ if (getRversion() >= "2.15.1") {
 #' Defaults to \code{0} (no arrows).
 #' @param arrow.gap a setting aimed at improving the display of edge arrows by
 #' plotting slightly shorter edges. Accepts any value between \code{0} and
-#' \code{1}, where values close to \code{0.95} will generally achieve good
-#' results if the size of the nodes is small.
+#' \code{1}, where a value of \code{0.05} will generally achieve good results
+#' when the size of the nodes is reasonably small.
 #' Defaults to \code{0} (no shortening).
 #' @param arrow.type the type of the arrows for directed network edges. See
 #' \code{\link[grid]{arrow}} for details.
@@ -240,7 +240,7 @@ if (getRversion() >= "2.15.1") {
 #'   ggnet2(n, edge.size = "weight", edge.label = "weight")
 #'
 #'   # edge arrows on a directed network
-#'   ggnet2(network(m, directed = TRUE), arrow.gap = 0.9, arrow.size = 10)
+#'   ggnet2(network(m, directed = TRUE), arrow.gap = 0.05, arrow.size = 10)
 #'
 #'   # Padgett's Florentine wedding data
 #'   data(flo, package = "network")
@@ -862,19 +862,13 @@ ggnet2 <- function(
       x.length = with(edges, abs(X2 - X1))
       y.length = with(edges, abs(Y2 - Y1))
 
-      k = 10
-      x.length = cut_interval(x.length, k, labels = 1:k)
-      y.length = cut_interval(y.length, k, labels = 1:k)
-
-      arrow.gap = rev(seq(arrow.gap - 0.05, arrow.gap, length.out = k))
-      x.length = arrow.gap[ x.length ]
-      y.length = arrow.gap[ y.length ]
+      arrow.gap = with(edges, arrow.gap / sqrt(x.length ^ 2 + y.length ^ 2))
 
       edges = transform(edges,
-                        X2 = X1 + x.length * (X2 - X1),
-                        Y2 = Y1 + y.length * (Y2 - Y1),
-                        X1 = X2 + x.length * (X1 - X2),
-                        Y1 = Y2 + y.length * (Y1 - Y2))
+                        X1 = X1 + arrow.gap * x.length,
+                        Y1 = Y1 + arrow.gap * y.length,
+                        X2 = X1 + (1 - arrow.gap) * x.length,
+                        Y2 = Y1 + (1 - arrow.gap) * y.length)
 
     }
 

--- a/tests/testthat/test-ggnet.R
+++ b/tests/testthat/test-ggnet.R
@@ -128,6 +128,14 @@ test_that("examples", {
   expect_error(ggnet(n, arrow.size = -1), "incorrect arrow.size")
   expect_warning(ggnet(n, arrow.size = 1), "arrow.size ignored")
 
+  ### --- test arrow.gap
+
+  expect_error(ggnet(n, arrow.size = 12, arrow.gap = -1), "incorrect arrow.gap")
+  expect_warning(ggnet(n, arrow.size = 12, arrow.gap = 0.1), "arrow.gap ignored")
+
+  m <- network::network(m, directed = TRUE)
+  ggnet(m, arrow.size = 12, arrow.gap = 0.1)
+
   ### --- test degree centrality
 
   ggnet(n, weight = "degree")

--- a/tests/testthat/test-ggnet.R
+++ b/tests/testthat/test-ggnet.R
@@ -134,7 +134,7 @@ test_that("examples", {
   expect_warning(ggnet(n, arrow.size = 12, arrow.gap = 0.1), "arrow.gap ignored")
 
   m <- network::network(m, directed = TRUE)
-  ggnet(m, arrow.size = 12, arrow.gap = 0.1)
+  ggnet(m, arrow.size = 12, arrow.gap = 0.9)
 
   ### --- test degree centrality
 

--- a/tests/testthat/test-ggnet.R
+++ b/tests/testthat/test-ggnet.R
@@ -134,7 +134,7 @@ test_that("examples", {
   expect_warning(ggnet(n, arrow.size = 12, arrow.gap = 0.1), "arrow.gap ignored")
 
   m <- network::network(m, directed = TRUE)
-  ggnet(m, arrow.size = 12, arrow.gap = 0.9)
+  ggnet(m, arrow.size = 12, arrow.gap = 0.05)
 
   ### --- test degree centrality
 

--- a/tests/testthat/test-ggnet.R
+++ b/tests/testthat/test-ggnet.R
@@ -211,10 +211,13 @@ test_that("examples", {
   ### --- test igraph functionality
 
   # test igraph conversion
-  n = asIgraph(n)
-  p = ggnet(n)
+  p = ggnet(asIgraph(n))
   expect_null(p$guides$colour)
   expect_equal(length(p$layers), 2)
+
+  # test igraph degree
+  library(igraph)
+  ggnet(n, weight = "degree")
 
   expect_true(TRUE)
 

--- a/tests/testthat/test-ggnet2.R
+++ b/tests/testthat/test-ggnet2.R
@@ -18,7 +18,7 @@ require(RColorBrewer , quietly = TRUE) # test ColorBrewer palettes
 test_that("examples", {
 
   ### --- start: documented examples
-  
+
   # random adjacency matrix
   x           <- 10
   ndyads      <- x * (x - 1)
@@ -27,59 +27,59 @@ test_that("examples", {
   dimnames(m) <- list(letters[ 1:x ], letters[ 1:x ])
   m[ row(m) != col(m) ] <- runif(ndyads) < density
   m
-  
+
   # random undirected network
   n <- network::network(m, directed = FALSE)
   n
-  
+
   ggnet2(n, label = TRUE)
   # ggnet2(n, label = TRUE, shape = 15)
   # ggnet2(n, label = TRUE, shape = 15, color = "black", label.color = "white")
-  
+
   # add vertex attribute
   x = network.vertex.names(n)
   x = ifelse(x %in% c("a", "e", "i"), "vowel", "consonant")
   n %v% "phono" = x
-  
+
   ggnet2(n, color = "phono")
   ggnet2(n, color = "phono", palette = c("vowel" = "gold", "consonant" = "grey"))
   ggnet2(n, shape = "phono", color = "phono")
-  
+
   # random groups
   n %v% "group" <- sample(LETTERS[1:3], 10, replace = TRUE)
   ggnet2(n, color = "group", palette = "Set2")
-  
+
   # random weights
   n %e% "weight" <- sample(1:3, network.edgecount(n), replace = TRUE)
   ggnet2(n, edge.size = "weight", edge.label = "weight")
-  
+
   # Padgett's Florentine wedding data
   data(flo, package = "network")
   flo
-  
+
   ggnet2(flo, label = TRUE)
   ggnet2(flo, label = TRUE, label.trim = 4, vjust = -1, size = 3, color = 1)
   # ggnet2(flo, label = TRUE, size = 12, color = "white")
-  
+
   ### --- end: documented examples
-  
+
   # test node assignment errors
   expect_error(ggnet2(n, color = NA))
   expect_error(ggnet2(n, color = -1))
   expect_error(ggnet2(n, color = rep("red", network.size(n) - 1)))
-  
+
   # test node assignment
   ggnet2(n, color = rep("red", network.size(n)))
-  
+
   # test node assignment errors
   expect_error(ggnet2(n, edge.color = NA))
   expect_error(ggnet2(n, edge.color = -1))
   expect_error(ggnet2(n, edge.color = rep("red", network.edgecount(n) - 1)))
-  
+
   # test edge assignment
   ggnet2(n, edge.color = rep("red", network.edgecount(n)))
   # ggnet2(n, edge.color = "weight")
-  
+
   # test mode = c("x", "y")
   ggnet2(n, mode = matrix(1, ncol = 2, nrow = 10))
   n %v% "x" = sample(1:10)
@@ -88,39 +88,47 @@ test_that("examples", {
   expect_error(ggnet2(n, mode = c("xx", "yy")), "not found")
   expect_error(ggnet2(n, mode = c("phono", "phono")), "not numeric")
   expect_error(ggnet2(n, mode = matrix(1, ncol = 2, nrow = 9)), "coordinates length")
-  
+
   # test arrow.size
   expect_error(ggnet2(n, arrow.size = -1), "incorrect arrow.size")
   expect_warning(ggnet2(n, arrow.size = 1), "arrow.size ignored")
-  
+
+  # test arrow.gap
+
+  expect_error(ggnet2(n, arrow.size = 12, arrow.gap = -1), "incorrect arrow.gap")
+  expect_warning(ggnet2(n, arrow.size = 12, arrow.gap = 0.1), "arrow.gap ignored")
+
+  m <- network::network(m, directed = TRUE)
+  ggnet2(m, arrow.size = 12, arrow.gap = 0.1)
+
   # test max_size
   expect_error(ggnet2(n, max_size = NA), "incorrect max_size")
-  
+
   # test na.rm
   expect_error(ggnet2(n, na.rm = 1:2), "incorrect na.rm")
   expect_error(ggnet2(n, na.rm = "xyz"), "not found")
-  
+
   n %v% "missing" = ifelse(n %v% "phono" == "vowel", NA, n %v% "phono")
   expect_message(ggnet2(n, na.rm = "missing"), "removed")
-  
+
   n %v% "missing" = NA
   expect_warning(ggnet2(n, na.rm = "missing"), "removed all nodes")
-  
+
   # test size = "degree"
   ggnet2(n, size = "degree")
-  
+
   # test size.min
   expect_error(ggnet2(n, size = "degree", size.min = -1), "incorrect size.min")
   expect_message(ggnet2(n, size = "degree", size.min = 1), "size.min removed")
   expect_warning(ggnet2(n, size = "abc", size.min = 1), "not numeric")
   expect_warning(ggnet2(n, size = 4, size.min = 5), "removed all nodes")
-  
+
   # test size.max
   expect_error(ggnet2(n, size = "degree", size.max = -1), "incorrect size.max")
   expect_message(ggnet2(n, size = "degree", size.max = 99), "size.max removed")
   expect_warning(ggnet2(n, size = "abc", size.max = 1), "not numeric")
   expect_warning(ggnet2(n, size = 4, size.max = 3), "removed all nodes")
-  
+
   # test size.cut
   ggnet2(n, size = 1:10, size.cut = 3)
   ggnet2(n, size = 1:10, size.cut = TRUE)
@@ -128,104 +136,104 @@ test_that("examples", {
   expect_error(ggnet2(n, size = 1:10, size.cut = "xyz"), "incorrect size.cut")
   expect_warning(ggnet2(n, size = "abc", size.cut = 3), "not numeric")
   expect_warning(ggnet2(n, size = 1, size.cut = 3), "ignored")
-  
+
   # test alpha.palette
   ggnet2(n, alpha = "phono", alpha.palette = c("vowel" = 1, "consonant" = 0.5))
   ggnet2(n, alpha = factor(1:10))
   expect_error(ggnet2(n, alpha = "phono", alpha.palette = c("vowel" = 1)), "no alpha.palette value")
-  
+
   # test color.palette
   # ggnet2(n, color = "phono", color.palette = c("vowel" = 1, "consonant" = 2))
   ggnet2(n, color = factor(1:10))
   ggnet2(n, color = "phono", palette = "Set1") # only 2 groups, palette has min. 3
   expect_error(ggnet2(n, color = factor(1:10), palette = "Set1"), "too many node groups")
   expect_error(ggnet2(n, color = "phono", color.palette = c("vowel" = 1)), "no color.palette value")
-  
+
   # test shape.palette
   ggnet2(n, shape = "phono", shape.palette = c("vowel" = 15, "consonant" = 19))
   expect_warning(ggnet2(n, shape = factor(1:10)), "discrete values")
   expect_error(ggnet2(n, shape = "phono", shape.palette = c("vowel" = 1)), "no shape.palette value")
-  
+
   # test size.palette
   ggnet2(n, size = "phono", size.palette = c("vowel" = 1, "consonant" = 2))
   ggnet2(n, size = factor(1:10))
   expect_error(ggnet2(n, size = "phono", size.palette = c("vowel" = 1)), "no size.palette value")
-  
+
   # test node.label
   ggnet2(n, label = sample(letters, 10))
   ggnet2(n, label = "phono")
-  
+
   # test label.alpha
   expect_error(ggnet2(n, label = TRUE, label.alpha = "xyz"), "incorrect label.alpha")
-  
+
   # test label.color
   expect_error(ggnet2(n, label = TRUE, label.color = "xyz"), "incorrect label.color")
-  
+
   # test label.size
   expect_error(ggnet2(n, label = TRUE, label.size = "xyz"), "incorrect label.size")
-  
+
   # test label.trim
   expect_error(ggnet2(n, label = TRUE, label.trim = "xyz"), "incorrect label.trim")
   ggnet2(n, label = TRUE, label.trim = toupper)
-  
+
   # test mode
   expect_error(ggnet2(n, mode = "xyz"), "unsupported")
   expect_error(ggnet2(n, mode = letters[1:3]), "incorrect mode")
-  
+
   # test edge.node shared colors
   ggnet2(n, color = "phono", edge.color = c("color", "grey"))
-  
+
   # test edge.color
   expect_error(ggnet2(n, edge.color = "xyz"), "incorrect edge.color")
-  
+
   # test edge.label.alpha
   expect_error(ggnet2(n, edge.label = "xyz", edge.label.alpha = "xyz"), "incorrect edge.label.alpha")
-  
+
   # test edge.label.color
   expect_error(ggnet2(n, edge.label = "xyz", edge.label.color = "xyz"), "incorrect edge.label.color")
-  
+
   # test edge.label.size
   expect_error(ggnet2(n, edge.label = "xyz", edge.label.size = "xyz"), "incorrect edge.label.size")
-  
+
   # test edge.size
   expect_error(ggnet2(n, edge.size = "xyz"), "incorrect edge.size")
-  
+
   # test layout.exp
   expect_error(ggnet2(n, layout.exp = "xyz"))
   ggnet2(n, layout.exp = 0.1)
-  
+
   ### --- test bipartite functionality
-  
+
   # weighted adjacency matrix
   bip = data.frame(event1 = c(1, 2, 1, 0),
                    event2 = c(0, 0, 3, 0),
                    event3 = c(1, 1, 0, 4),
                    row.names = letters[1:4])
-  
+
   # weighted bipartite network
   bip = network(bip,
                 matrix.type = "bipartite",
                 ignore.eval = FALSE,
                 names.eval = "weights")
-  
+
   # test bipartite mode
   ggnet2(bip, color = "mode")
-  
+
   ### --- test network coercion
-  
+
   expect_warning(ggnet2(network(matrix(1, nrow = 2, ncol = 2), loops = TRUE)), "self-loops")
-  
+
   expect_error(ggnet2(1:2), "network object")
   expect_error(ggnet2(network(data.frame(1:2, 3:4), hyper = TRUE)), "hyper graphs")
   expect_error(ggnet2(network(data.frame(1:2, 3:4), multiple = TRUE)), "multiplex graphs")
-  
+
   ### --- test igraph functionality
-  
+
   # test igraph conversion
   n = asIgraph(n)
   p = ggnet2(n, color = "group")
   expect_null(p$guides$colour)
-  
+
   expect_true(TRUE)
-  
+
 })

--- a/tests/testthat/test-ggnet2.R
+++ b/tests/testthat/test-ggnet2.R
@@ -99,7 +99,7 @@ test_that("examples", {
   expect_warning(ggnet2(n, arrow.size = 12, arrow.gap = 0.1), "arrow.gap ignored")
 
   m <- network::network(m, directed = TRUE)
-  ggnet2(m, arrow.size = 12, arrow.gap = 0.9)
+  ggnet2(m, arrow.size = 12, arrow.gap = 0.05)
 
   # test max_size
   expect_error(ggnet2(n, max_size = NA), "incorrect max_size")

--- a/tests/testthat/test-ggnet2.R
+++ b/tests/testthat/test-ggnet2.R
@@ -230,9 +230,12 @@ test_that("examples", {
   ### --- test igraph functionality
 
   # test igraph conversion
-  n = asIgraph(n)
-  p = ggnet2(n, color = "group")
+  p = ggnet2(asIgraph(n), color = "group")
   expect_null(p$guides$colour)
+
+  # test igraph degree
+  library(igraph)
+  ggnet2(n, size = "degree")
 
   expect_true(TRUE)
 

--- a/tests/testthat/test-ggnet2.R
+++ b/tests/testthat/test-ggnet2.R
@@ -99,7 +99,7 @@ test_that("examples", {
   expect_warning(ggnet2(n, arrow.size = 12, arrow.gap = 0.1), "arrow.gap ignored")
 
   m <- network::network(m, directed = TRUE)
-  ggnet2(m, arrow.size = 12, arrow.gap = 0.1)
+  ggnet2(m, arrow.size = 12, arrow.gap = 0.9)
 
   # test max_size
   expect_error(ggnet2(n, max_size = NA), "incorrect max_size")

--- a/tests/testthat/test-ggnetworkmap.R
+++ b/tests/testthat/test-ggnetworkmap.R
@@ -1,6 +1,10 @@
 
 context("ggnetworkmap")
 
+if ("package:igraph" %in% search()) {
+  detach("package:igraph")
+}
+
 require(network)
 require(sna)
 require(maps)


### PR DESCRIPTION
The `arrow.gap` option provides a way to improve the visualization of edge arrows in `ggnet` and `ggnet2`.

- The code has been tested with both the CRAN version of `ggplot2` and with the GitHub development version (1.0.1.9003).
- The vignette for `ggnet2` has been updated to show [how the option works](https://briatte.github.io/ggnet/#edge-arrows).
- Coverage tests have been added to keep coverage above ~~95%~~ 99%.