### PR TITLE
set all-NA panels to blank, skip cor()

### DIFF
--- a/R/find-combo.R
+++ b/R/find-combo.R
@@ -65,6 +65,8 @@ find_plot_type <- function(data, col1, col2) {
     }
   }
 
+  if (all(is.na(data[,col1]) | is.na(data[,col2])))
+      return("blank")
   return("scatterplot")
 
 }

--- a/R/gg-plots.R
+++ b/R/gg-plots.R
@@ -188,7 +188,8 @@ ggally_cor <- function(
 
   cor_fn <- function(x, y) {
     # also do ddply below if fn is altered
-    cor(x, y, method = method, use = use)
+      if (all(is.na(x) | is.na(y))) NA else    
+      cor(x, y, method = method, use = use)
   }
 
   # xVar <- data[,as.character(mapping$x)]

--- a/tests/testthat/test-allNA.R
+++ b/tests/testthat/test-allNA.R
@@ -1,0 +1,6 @@
+context("allNA")
+
+test_that("allNA", {
+              dd <- data.frame(x=c(1:5,rep(NA,5)),y=c(rep(NA,5),2:6),z=1:10)
+              ggpairs(dd)
+          })


### PR DESCRIPTION
this is a fairly minor change that allows `ggpairs()` to proceed when a panel is completely full of NAs.  (The use case here is that we have some pairs of variables where exactly one was measured in each year.  It's nice to be able to include these pairs along with other variables that were measured in every year.)

```
   dd <- data.frame(x=c(1:5,rep(NA,5)),y=c(rep(NA,5),2:6),z=1:10)
              ggpairs(dd)
```