### PR TITLE
Fixed #120:'uniminmax' scaling error for columns containing one single numeric value only. Added corresponding tests that confirm the error is not thrown anymore.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@ README.html
 notes/
 tests/testthat/Rplots.pdf
 revdep
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ inst/*
 tests/testthat/Rplots.pdf
 vignettes/figure
 vignettes/*.html
+.Rproj.user
+.RData
+ggally_.Rproj

--- a/R/ggparcoord.R
+++ b/R/ggparcoord.R
@@ -2,9 +2,7 @@ if(getRversion() >= "2.15.1") {
   utils::globalVariables(c("variable", "value", "ggally_splineFactor"))
 }
 
-##### KNOWN BUGS #####
-# - It does not currently work to pass groupColumn one of the variables that is being plotted
-#   as an axis
+
 
 #' ggparcoord - A ggplot2 Parallel Coordinate Plot
 #'
@@ -309,12 +307,11 @@ ggparcoord <- function(
   inner_rescaler <- function(x, type = "sd", ...) {
     # copied directly from reshape because of import difficulties :-(
     # rescaler.data.frame
-    continuous    <- sapply(x, is.numeric)
+    continuous <- sapply(x, is.numeric)
     if (any(continuous)) {
       if (type %in% c("sd", "robust", "range")) {
         singleVal    <- sapply(x, function(col){if(length(unique(col)) == 1) TRUE else FALSE}) # indicating columns containing only one single value
-        isFactor     <- as.vector(sapply(x, is.factor))
-        ind          <- continuous & !singleVal & !isFactor
+        ind          <- continuous & !singleVal
         x[ind]       <- lapply(x[ind], inner_rescaler_default, type = type, ...)
         x[singleVal] <- 1
       }

--- a/R/ggparcoord.R
+++ b/R/ggparcoord.R
@@ -309,9 +309,18 @@ ggparcoord <- function(
   inner_rescaler <- function(x, type = "sd", ...) {
     # copied directly from reshape because of import difficulties :-(
     # rescaler.data.frame
-    continuous <- sapply(x, is.numeric)
+    continuous    <- sapply(x, is.numeric)
     if (any(continuous)) {
-      x[continuous] <- lapply(x[continuous], inner_rescaler_default, type = type, ...)
+      if (type %in% c("sd", "robust", "range")) {
+        singleVal    <- sapply(x, function(col){if(length(unique(col)) == 1) TRUE else FALSE}) # indicating columns containing only one single value
+        isFactor     <- as.vector(sapply(x, is.factor))
+        ind          <- continuous & !singleVal & !isFactor
+        x[ind]       <- lapply(x[ind], inner_rescaler_default, type = type, ...)
+        x[singleVal] <- 1
+      }
+      else {
+         x[continuous] <- lapply(x[continuous], inner_rescaler_default, type = type, ...)
+       }
     }
     x
   }

--- a/tests/testthat/test-ggparcoord.R
+++ b/tests/testthat/test-ggparcoord.R
@@ -249,3 +249,19 @@ test_that("size", {
   expect_equal(as.character(p$mapping$size), "gear")
 
 })
+
+
+test_that("columns containing only a single value do not cause an scaling error", {
+   df <- data.frame(obs = 1:5, var1 = sample(10,5), var2 = rep(3, 5))
+
+   # no scaling
+   expect_that(ggparcoord(data = df, columns = 1:3, scale = "globalminmax"), not(throws_error()))
+   # requires scaling, must not throw an errror due to scaling the single values (to NaN)
+   expect_that(ggparcoord(data = df, columns = 1:3, scale = "uniminmax"), not(throws_error()))
+
+
+   df <- data.frame(df, var3 = factor(c("a","b","c","a","c")))
+   # requires scaling, must not throw an errror due to scaling the single values (to NaN)
+   expect_that(ggparcoord(data = df, columns = 1:4, scale = "uniminmax"), not(throws_error()))
+})
+

--- a/tests/testthat/test-ggparcoord.R
+++ b/tests/testthat/test-ggparcoord.R
@@ -252,16 +252,22 @@ test_that("size", {
 
 
 test_that("columns containing only a single value do not cause an scaling error", {
-   df <- data.frame(obs = 1:5, var1 = sample(10,5), var2 = rep(3, 5))
+  df <- data.frame(obs = 1:5, var1 = sample(10,5), var2 = rep(3, 5))
 
-   # no scaling
-   expect_that(ggparcoord(data = df, columns = 1:3, scale = "globalminmax"), not(throws_error()))
-   # requires scaling, must not throw an errror due to scaling the single values (to NaN)
-   expect_that(ggparcoord(data = df, columns = 1:3, scale = "uniminmax"), not(throws_error()))
+  # no scaling
+  expect_that(ggparcoord(data = df, columns = 1:3, scale = "globalminmax"), not(throws_error()))
+  # requires scaling, must not throw an errror due to scaling the single values (to NaN)
+  expect_that(ggparcoord(data = df, columns = 1:3, scale = "uniminmax"), not(throws_error()))
 
 
-   df <- data.frame(df, var3 = factor(c("a","b","c","a","c")))
-   # requires scaling, must not throw an errror due to scaling the single values (to NaN)
-   expect_that(ggparcoord(data = df, columns = 1:4, scale = "uniminmax"), not(throws_error()))
+  df2 <- data.frame(df, var3 = factor(c("a","b","c","a","c")))
+  # requires scaling, must not throw an errror due to scaling the single values (to NaN)
+  expect_that(ggparcoord(data = df2, columns = 1:4, scale = "uniminmax"), not(throws_error()))
+
+
+  df3 <- data.frame(df2, var4 = factor(c("d","d","d","d","d")))
+  expect_that(ggparcoord(data = df3, columns = 1:4, scale = "uniminmax"), not(throws_error()))
+  expect_that(ggparcoord(data = df3, columns = 1:4, scale = "robust"), not(throws_error()))
+  expect_that(ggparcoord(data = df3, columns = 1:4, scale = "std"), not(throws_error()))
 })
 


### PR DESCRIPTION
Fixes issue #120.