### PR TITLE
do not turn the color column into a numeric

### DIFF
--- a/R/ggparcoord.R
+++ b/R/ggparcoord.R
@@ -276,6 +276,9 @@ ggparcoord <- function(
 
   # Change factors to numeric
   fact.vars <- column_is_factor(data)
+  if(!is.null(groupColumn)) {
+    fact.vars <- fact.vars[fact.vars != groupCol]
+  }
   if (length(fact.vars) >= 1) {
     for (fact.var in fact.vars) {
       data[,fact.var] <- as.numeric(data[,fact.var])


### PR DESCRIPTION
```{r}
load_all()

library(ggplot2)
data(diamonds)

diamonds.samp <- diamonds[sample(1:nrow(diamonds), 1000), ]

ggparcoord(data = diamonds.samp,columns = c(1,5:10), groupColumn = 2)
```

Before (wrong):
![screenshot 2016-01-06 09 32 10](https://cloud.githubusercontent.com/assets/93231/12144833/682d5742-b458-11e5-957a-3b6f2a8c7ab7.png)

With PR:
(different sample)
![screenshot 2016-01-06 09 33 32](https://cloud.githubusercontent.com/assets/93231/12144855/912a9e52-b458-11e5-8d88-21123aeee674.png)


```{r}
ggparcoord(data = diamonds.samp,columns = c(1,5:10), groupColumn = "x")
```
Continuous still works
![screenshot 2016-01-06 09 34 12](https://cloud.githubusercontent.com/assets/93231/12144875/b6a31ff6-b458-11e5-9504-68a13bb69d4d.png)
