### PR TITLE
fix with labelling of cor_matrix with ggcorr

### DIFF
--- a/R/ggcorr.R
+++ b/R/ggcorr.R
@@ -72,9 +72,7 @@ if (getRversion() >= "2.15.1") {
 #' @param midpoint the midpoint value for continuous scaling of the
 #' correlation coefficients.
 #' Defaults to \code{0}.
-#' @param limits whether to bound the color scaling of the correlation
-#' coefficients between -1 and +1.
-#' Defaults to \code{TRUE} (recommended).
+#' @param limits bounding of color scaling for correlations, set \code{limits = NULL} to remove
 #' @param drop if using \code{nbreaks}, whether to drop unused breaks from the
 #' color scale.
 #' Defaults to \code{FALSE} (recommended).
@@ -151,7 +149,7 @@ ggcorr <- function(
   label_color = "black",
   label_round = 1,
   label_size = 4,
-  limits = TRUE,
+  limits = c(-1, 1),
   drop = !limits,
   layout.exp = 0,
   legend.position = "right",
@@ -260,17 +258,17 @@ ggcorr <- function(
 
     # -- tiles, color scale ----------------------------------------------------
 
-    if (is.null(nbreaks) && limits) {
+    if (is.null(nbreaks) && !is.null(limits)) {
 
       p = p +
         scale_fill_gradient2(name, low = low, mid = mid, high = high,
-                             midpoint = midpoint, limits = c(-1, 1))
+                             midpoint = midpoint, limits = limits)
 
     } else if (is.null(nbreaks)) {
 
-      p = p +
-        scale_fill_gradient2(name, low = low, mid = mid, high = high,
-                             midpoint = midpoint)
+        p = p +
+          scale_fill_gradient2(name, low = low, mid = mid, high = high,
+                               midpoint = midpoint)
 
     } else if (is.null(palette)) {
 
@@ -315,11 +313,11 @@ ggcorr <- function(
 
     # -- circles, color scale --------------------------------------------------
 
-    if (is.null(nbreaks) && limits) {
+    if (is.null(nbreaks) && !is.null(limits)) {
 
       p = p +
         scale_color_gradient2(name, low = low, mid = mid, high = high,
-                              midpoint = midpoint, limits = c(-1, 1))
+                              midpoint = midpoint, limits = limits)
 
     } else if (is.null(nbreaks)) {
 
@@ -363,11 +361,11 @@ ggcorr <- function(
 
     # -- text, color scale ----------------------------------------------------
 
-    if (is.null(nbreaks) && limits) {
+    if (is.null(nbreaks) && !is.null(limits)) {
 
       p = p +
         scale_color_gradient2(name, low = low, mid = mid, high = high,
-                              midpoint = midpoint, limits = c(-1, 1))
+                              midpoint = midpoint, limits = limits)
 
     } else if (is.null(nbreaks)) {
 

--- a/R/ggcorr.R
+++ b/R/ggcorr.R
@@ -204,6 +204,7 @@ ggcorr <- function(
   # -- correlation data.frame --------------------------------------------------
 
   m = data.frame(m * lower.tri(m))
+  rownames(m) = names(m)
   m$.ggally_ggcorr_row_names = rownames(m)
   m = reshape::melt(m, id.vars = ".ggally_ggcorr_row_names")
   names(m) = c("x", "y", "coefficient")

--- a/ggally.Rproj
+++ b/ggally.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/man/ggcorr.Rd
+++ b/man/ggcorr.Rd
@@ -9,7 +9,7 @@ ggcorr(data, method = c("pairwise", "pearson"), cor_matrix = NULL,
   mid = "#EEEEEE", high = "#F21A00", midpoint = 0, palette = NULL,
   geom = "tile", min_size = 2, max_size = 6, label = FALSE,
   label_alpha = FALSE, label_color = "black", label_round = 1,
-  label_size = 4, limits = TRUE, drop = !limits, layout.exp = 0,
+  label_size = 4, limits = c(-1, 1), drop = !limits, layout.exp = 0,
   legend.position = "right", legend.size = 9, ...)
 }
 \arguments{
@@ -92,9 +92,7 @@ Defaults to \code{1}.}
 \item{label_size}{the size of the correlation coefficients.
 Defaults to \code{4}.}
 
-\item{limits}{whether to bound the color scaling of the correlation
-coefficients between -1 and +1.
-Defaults to \code{TRUE} (recommended).}
+\item{limits}{bounding of color scaling for correlations, set \code{limits = NULL} to remove}
 
 \item{drop}{if using \code{nbreaks}, whether to drop unused breaks from the
 color scale.


### PR DESCRIPTION
`ggcorr` plots were not rendering for some cases of user-supplied correlation matrices.  This was related to a problem with the column/row names during conversion from matrix to data.frame for plotting.  Try the example below using the older version and with the new pull request:

```r
library(GGally)
sides <-20
dat <- runif(sides^2, -1, 1)
dat <- matrix(dat, ncol = sides)
diag(dat) <- 1
ggcorr(data = NULL, cor_matrix = dat)
```