### PR TITLE
Order labels in ggsurv plots so they correspond to the ordering of the survival curves

### DIFF
--- a/R/ggsurv.R
+++ b/R/ggsurv.R
@@ -207,6 +207,7 @@ ggsurv_m <- function(
     }
     return(res)
   }
+  
   lastv = ugroups[order(getlast(s),decreasing=T)]
   groups = factor(ugroups,levels = lastv)
   gr.name <-  strataEqualNames[1]

--- a/R/ggsurv.R
+++ b/R/ggsurv.R
@@ -197,11 +197,18 @@ ggsurv_m <- function(
   n <- s$strata
 
   strataEqualNames <- unlist(strsplit(names(s$strata), '='))
-  groups <- factor(
-    strataEqualNames[seq(2, 2 * strata, by = 2)],
-    levels = strataEqualNames[seq(2, 2 * strata, by = 2)]
-  )
-
+  ugroups <- unlist(strsplit(names(s$strata), '='))[seq(2, 2*strata, by = 2)]
+  getlast = function(x) {
+    res=NULL
+    for (mo in names(x$strata)) {
+      sur = x[mo]$surv
+      n = length(sur)
+      res = append(res,sur[n])
+    }
+    return(res)
+  }
+  lastv = ugroups[order(getlast(s),decreasing=T)]
+  groups = factor(ugroups,levels = lastv)
   gr.name <-  strataEqualNames[1]
   gr.df   <- vector('list', strata)
   n.ind   <- cumsum(c(0,n))

--- a/R/ggsurv.R
+++ b/R/ggsurv.R
@@ -197,11 +197,19 @@ ggsurv_m <- function(
   n <- s$strata
 
   strataEqualNames <- unlist(strsplit(names(s$strata), '='))
-  groups <- factor(
-    strataEqualNames[seq(2, 2 * strata, by = 2)],
-    levels = strataEqualNames[seq(2, 2 * strata, by = 2)]
-  )
-
+  ugroups <- unlist(strsplit(names(s$strata), '='))[seq(2, 2*strata, by = 2)]
+  getlast = function(x) {
+    res=NULL
+    for (mo in names(x$strata)) {
+      sur = x[mo]$surv
+      n = length(sur)
+      res = append(res,sur[n])
+    }
+    return(res)
+  }
+  lastv = ugroups[order(getlast(s),decreasing=T)]
+  groups = factor(ugroups,levels = lastv)
+  
   gr.name <-  strataEqualNames[1]
   gr.df   <- vector('list', strata)
   n.ind   <- cumsum(c(0,n))

--- a/R/ggsurv.R
+++ b/R/ggsurv.R
@@ -197,19 +197,11 @@ ggsurv_m <- function(
   n <- s$strata
 
   strataEqualNames <- unlist(strsplit(names(s$strata), '='))
-  ugroups <- unlist(strsplit(names(s$strata), '='))[seq(2, 2*strata, by = 2)]
-  getlast = function(x) {
-    res=NULL
-    for (mo in names(x$strata)) {
-      sur = x[mo]$surv
-      n = length(sur)
-      res = append(res,sur[n])
-    }
-    return(res)
-  }
-  lastv = ugroups[order(getlast(s),decreasing=T)]
-  groups = factor(ugroups,levels = lastv)
-  
+  groups <- factor(
+    strataEqualNames[seq(2, 2 * strata, by = 2)],
+    levels = strataEqualNames[seq(2, 2 * strata, by = 2)]
+  )
+
   gr.name <-  strataEqualNames[1]
   gr.df   <- vector('list', strata)
   n.ind   <- cumsum(c(0,n))


### PR DESCRIPTION
update: travis-ci tests passed

Change from factor default ordering to an ordered factor for group in ggsurv_m where order is given by the LAST survival value for each stratum. 

This makes finding the label for each curve MUCH easier on the plots IMHO because there's a logical/visual clue that (eg) the bottom line or at least the one with the lowest survival at the end of the curve (where the label is!) corresponds to the bottom line of the legend.

Sorry, not yet tested with travis.ci - it seems to be broken trying to import my new fork....but tested with my own data and seems fine - eg see the plots at http://imgur.com/a/rH6Ot where the ordering corresponds to the curve order more or less.
