### PR TITLE
ggally_ratio

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,13 +13,25 @@ ggally_smooth
 
 * added 'method' parameter (411213c)
 
-ggnetworkmap
+ggally_ratio
 
-* fixed issue with overlaying network on a world map PR#157
+* Does not call ggfluctuation2 anymore. PR#165
 
 ggcorr
 
 * fixed issue with unnamed correlation matrix used as input PR#146
+
+ggfluctuation2
+
+* is being deprecated. Please use ggally_ratio instead PR#165
+
+ggnetworkmap
+
+* fixed issue with overlaying network on a world map PR#157
+
+ggpairs
+
+* Fixed improperly rotated axes with ggally_ratio PR#165
 
 ggscatmat
 

--- a/R/gg-plots.R
+++ b/R/gg-plots.R
@@ -1199,6 +1199,7 @@ ggally_facetbar <- function(data, mapping, ...){
 #'
 #' A fluctutation diagram is a graphical representation of a contingency table. This fuction currently only supports 2D contingency tables.
 #' The function was adopted from experiemntal functions within GGplot2 developed by Hadley Wickham.
+#' Fluctuation plot - deprecated
 #'
 #' @param table_data a table of values, or a data frame with three columns, the last column being frequency
 #' @param floor don't display cells smaller than this value
@@ -1212,6 +1213,8 @@ ggally_facetbar <- function(data, mapping, ...){
 #' ggfluctuation2(table(tips$sex, tips$day))
 #' ggfluctuation2(table(tips[, c("sex", "day")]))
 ggfluctuation2 <- function (table_data, floor = 0, ceiling = max(table_data$freq, na.rm = TRUE)) {
+
+  warning("'ggfluctuation2' is being depricated and will be removed in future versions.  Please migrate to ggally_ratio")
 
   yNames <- rownames(table_data)
   xNames <- colnames(table_data)
@@ -1251,7 +1254,6 @@ ggfluctuation2 <- function (table_data, floor = 0, ceiling = max(table_data$freq
   # print(yNames)
   #
   # cat("\nmaxLen");print(maxLen)
-
 
   p <- ggplot(
       table_data,

--- a/R/ggpairs.R
+++ b/R/ggpairs.R
@@ -402,22 +402,15 @@ ggpairs <- function(
 
       comboAes <- add_and_overwrite_aes(plotAes, sectionAes)
 
-      if (identical(subTypeName, "ggally_ratio")) {
-        p <- ggally_ratio(data[, c(yColName, xColName)])
-
-      } else {
-
-        if (identical(subTypeName, "ggally_facetbar")) {
-          if (!is.null(comboAes$colour)) {
-            comboAes <- add_and_overwrite_aes(comboAes, aes_string(fill = comboAes$colour))
-          }
+      if (identical(subTypeName, "ggally_facetbar")) {
+        if (!is.null(comboAes$colour)) {
+          comboAes <- add_and_overwrite_aes(comboAes, aes_string(fill = comboAes$colour))
         }
-        p <- make_ggmatrix_plot_obj(
-          wrap_fn_with_param_arg(subType, params = c(), funcArgName = subTypeName),
-          mapping = comboAes
-        )
-
       }
+      p <- make_ggmatrix_plot_obj(
+        wrap_fn_with_param_arg(subType, params = c(), funcArgName = subTypeName),
+        mapping = comboAes
+      )
 
     } else if (type %in% c("stat_bin-num", "stat_bin-cat", "label")) {
       plotAes$y <- NULL

--- a/man/ggally_ratio.Rd
+++ b/man/ggally_ratio.Rd
@@ -2,26 +2,34 @@
 % Please edit documentation in R/gg-plots.R
 \name{ggally_ratio}
 \alias{ggally_ratio}
-\title{Plots a mosaic plots}
+\title{Plots a mosaic plot}
 \usage{
-ggally_ratio(data)
+ggally_ratio(data, mapping = do.call(ggplot2::aes_string,
+  as.list(colnames(data)[1:2])), ..., floor = 0, ceiling = NULL)
 }
 \arguments{
 \item{data}{data set using}
+
+\item{mapping}{aesthetics being used. Only x and y will used and both are required}
+
+\item{...}{ignored}
+
+\item{floor}{don't display cells smaller than this value}
+
+\item{ceiling}{max value to scale frequencies.  If any frequency is larger than the ceiling, the fill color is displayed darker than other rectangles}
 }
 \description{
 Plots the mosaic plot by using fluctuation.
 }
-\details{
-Must send only two discrete columns in the data set.
-}
 \examples{
 data(tips, package = "reshape")
-ggally_ratio(tips[, c("sex", "smoker")])
-ggally_ratio(tips[, c("sex", "smoker")]) + ggplot2::coord_equal()
+ggally_ratio(tips, ggplot2::aes(sex, day))
+ggally_ratio(tips, ggplot2::aes(sex, day)) + ggplot2::coord_equal()
+# only plot tiles greater or equal to 20 and scale to a max of 50
 ggally_ratio(
-  tips[, c("sex", "day")]
-) + ggplot2::theme( aspect.ratio = 4/2)
+  tips, ggplot2::aes(sex, day),
+  floor = 20, ceiling = 50
+) + ggplot2::theme(aspect.ratio = 4/2)
 }
 \author{
 Barret Schloerke \email{schloerke@gmail.com}

--- a/man/ggfluctuation2.Rd
+++ b/man/ggfluctuation2.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/gg-plots.R
 \name{ggfluctuation2}
 \alias{ggfluctuation2}
-\title{Fluctuation plot}
+\title{Fluctuation plot - deprecated}
 \usage{
 ggfluctuation2(table_data, floor = 0, ceiling = max(table_data$freq, na.rm =
   TRUE))
@@ -15,11 +15,7 @@ ggfluctuation2(table_data, floor = 0, ceiling = max(table_data$freq, na.rm =
 \item{ceiling}{max value to compare to}
 }
 \description{
-Create a fluctuation plot.
-}
-\details{
-A fluctutation diagram is a graphical representation of a contingency table. This fuction currently only supports 2D contingency tables.
-The function was adopted from experiemntal functions within GGplot2 developed by Hadley Wickham.
+Fluctuation plot - deprecated
 }
 \examples{
 data(tips, package = "reshape")


### PR DESCRIPTION
fix for issue: #165

former incorrect ggally_ratio (in ggpairs) picture:
<img src="https://cloud.githubusercontent.com/assets/10579349/15340095/b136ea1a-1c55-11e6-9524-1b7ccfa92bd4.png"></img>

newer code:
```{r}
mtcars$cyl <- as.factor(mtcars$cyl)
mtcars$carb <- as.factor(mtcars$carb)
ggpairs(mtcars[,c("mpg", "cyl", "carb")], lower = list(discrete = "ratio"), showStrips = TRUE)
```
![screen shot 2016-05-18 at 2 43 49 pm](https://cloud.githubusercontent.com/assets/93231/15370895/fe8d2912-1d06-11e6-934d-b853e73622f9.png)

Extreme situation:
```{r}
ggpairs(mtcars[,c("cyl", "carb", "cyl", "carb")], lower = list(discrete = wrap("ratio", floor = 4, ceiling = 5)), showStrips = TRUE)
```
![screen shot 2016-05-18 at 2 48 17 pm](https://cloud.githubusercontent.com/assets/93231/15371050/ab975f06-1d07-11e6-893c-5b271af3df87.png)
