### PR TITLE
fixed issue where setting layout.exp to a non-zero value causes bad shift

### DIFF
--- a/R/ggcorr.R
+++ b/R/ggcorr.R
@@ -450,7 +450,7 @@ ggcorr <- function(
   }
 
   p = p  +
-    geom_text(data = textData, aes(label = diagLabel), ..., na.rm = TRUE) +
+    geom_text(data = textData, aes_string(label = "diagLabel"), ..., na.rm = TRUE) +
     scale_x_discrete(breaks = NULL, limits = xLimits) +
     scale_y_discrete(breaks = NULL, limits = levels(m$y)) +
     labs(x = NULL, y = NULL) +

--- a/R/ggcorr.R
+++ b/R/ggcorr.R
@@ -431,18 +431,27 @@ ggcorr <- function(
 
   # -- horizontal scale expansion ----------------------------------------------
 
-  l = levels(m$y)
+  textData <- m[ m$x == m$y & is.na(m$coefficient), ]
+  xLimits <- levels(textData$y)
+  textData$diagLabel <- textData$x
 
   if (!is.numeric(layout.exp) || layout.exp < 0) {
     stop("incorrect layout.exp value")
   } else if (layout.exp > 0) {
-    l = c(rep(NA, as.integer(layout.exp)), l)
+    layout.exp <- as.integer(layout.exp)
+    # copy to fill in spacer info
+    textData <- rbind(textData[1:layout.exp, ], textData)
+
+    spacer <- paste(".ggally_ggcorr_spacer_value", 1:layout.exp, sep = "")
+
+    textData$x[1:layout.exp] <- spacer
+    textData$diagLabel[1:layout.exp] <- NA
+    xLimits <- c(spacer, levels(m$y))
   }
 
   p = p  +
-    geom_text(data = m[ m$x == m$y & is.na(m$coefficient), ],
-              aes(label = x), ...) +
-    scale_x_discrete(breaks = NULL, limits = l) +
+    geom_text(data = textData, aes(label = diagLabel), ..., na.rm = TRUE) +
+    scale_x_discrete(breaks = NULL, limits = xLimits) +
     scale_y_discrete(breaks = NULL, limits = levels(m$y)) +
     labs(x = NULL, y = NULL) +
     coord_equal() +


### PR DESCRIPTION
Fixes issue #170 

```{r}
set.seed(123)
df <- data.frame(matrix(rnorm(100), nrow=10))
colnames(df) <- paste("reallylongnamethatwillgetcutoff_X", 1:10, sep = "")

ggcorr(df, layout.exp=0, geom="circle", hjust = 0.95) + 
  theme(panel.background = element_rect(colour = "black"))
```
![screen shot 2016-05-31 at 12 46 23 pm](https://cloud.githubusercontent.com/assets/93231/15683119/ca0420ba-272e-11e6-86b9-12022a10fc94.png)
```{r}
ggcorr(df, layout.exp=6, geom="circle", hjust = 0.95) + 
  theme(panel.background = element_rect(colour = "black"))
```
![screen shot 2016-05-31 at 12 46 53 pm](https://cloud.githubusercontent.com/assets/93231/15683126/cf3eb446-272e-11e6-922a-b95ff029d825.png)
```{r}
ggcorr(df, layout.exp=0, geom="text", hjust = 0.95) + 
  theme(panel.background = element_rect(colour = "black"))
```
![screen shot 2016-05-31 at 12 55 25 pm](https://cloud.githubusercontent.com/assets/93231/15683166/f8cccb4a-272e-11e6-8422-133ddbeaf337.png)
```{r}
ggcorr(df, layout.exp=6, geom="text", hjust = 0.95) + 
  theme(panel.background = element_rect(colour = "black"))
```
![screen shot 2016-05-31 at 12 50 48 pm](https://cloud.githubusercontent.com/assets/93231/15683150/e544d342-272e-11e6-8999-085ddc6d52a0.png)
