### PR TITLE
fortify data to support more 'data' objects

### DIFF
--- a/R/ggpairs.R
+++ b/R/ggpairs.R
@@ -31,6 +31,7 @@
 
 
 fix_data <- function(data) {
+  data <- fortify(data)
   data <- as.data.frame(data)
   for (i in 1:dim(data)[2] ) {
     if (is.character(data[, i])) {


### PR DESCRIPTION
This small change would allow me to do the following 🔥 🔥 🔥 

```r
devtools::install_github("ropensci/plotly#554")
library(plotly)
library(GGally)
iris$id <- seq_len(nrow(iris))
SharedData$new(iris, ~id) %>%
  ggpairs(columns = 1:4) %>%
  ggplotly()
```

![gglink](https://cloud.githubusercontent.com/assets/1365941/17273674/51c9d890-5683-11e6-893d-71c3b03793f6.gif)
