### PR TITLE
use a labeller for expressions in ggmatrix print

### DIFF
--- a/R/ggmatrix_gtable.R
+++ b/R/ggmatrix_gtable.R
@@ -37,17 +37,38 @@ ggmatrix_gtable <- function(
 
 
   # make a fake facet grid to fill in with proper plot panels
+  get_labels <- function(labels, length_out) {
+    if (is.null(labels)) {
+      # no labels supplied
+      as.character(seq_len(length_out))
+    } else if (is.expression(labels)) {
+      # expressions supplied. must be paired with ggplot2::label_parsed
+      unlist(lapply(as.list(labels), as.character))
+    } else {
+      labels
+    }
+  }
   fake_data <- expand.grid(
-    Var1 = ifnull(pm$xAxisLabels, as.character(seq_len(pm$ncol))),
-    Var2 = ifnull(pm$yAxisLabels, as.character(seq_len(pm$nrow)))
+    Var1 = get_labels(pm$xAxisLabels, pm$ncol),
+    Var2 = get_labels(pm$yAxisLabels, pm$nrow)
   )
   fake_data$x <- 1
   fake_data$y <- 1
 
+  if (
+    (is.expression(pm$xAxisLabels) || is.expression(pm$yAxisLabels))
+  ) {
+    # works with expressions
+    labeller <- ggplot2::label_parsed
+  } else {
+    # works with raw characters
+    labeller <- ggplot2::label_value
+  }
+
   # make the smallest plot possible so the guts may be replaced
   pm_fake <- ggplot(fake_data, mapping = aes_("x", "y")) +
     geom_point() +
-    facet_grid(Var2 ~ Var1) + # make the 'fake' strips for x and y titles
+    facet_grid(Var2 ~ Var1, labeller = labeller) + # make the 'fake' strips for x and y titles
     labs(x = pm$xlab, y = pm$ylab) # remove both x and y titles
 
   # add all custom ggplot2 things

--- a/tests/testthat/test-ggmatrix.R
+++ b/tests/testthat/test-ggmatrix.R
@@ -24,6 +24,17 @@ test_that("stops", {
 
 })
 
+
+test_that("expression labels", {
+  chars <- c("col1", "col2")
+  exprs <- expression(alpha, beta)
+
+  expect_print(ggduo(tips, 1:2, 1:2, columnLabelsX = chars, columnLabelsY = exprs))
+  expect_print(ggduo(tips, 1:2, 1:2, columnLabelsX = exprs, columnLabelsY = chars))
+  expect_print(ggpairs(tips, 1:2, columnLabels = exprs))
+})
+
+
 test_that("byrow", {
   plotList <- list()
   for (i in 1:6) {


### PR DESCRIPTION
Fixes #207 

Logic: 
- if label is expression, make into character vector to be able to facet on the "column" col
- if label is expression, use `labeller  = label_parsed`, else use `labeller = label_value`

@jonathan-g   Please install to test on your end.  Thank you for the example!

```r
devtools::install_github("ggobi/ggally@labeller")
```

```{r}
library(tibble)
df <- data_frame(x = rnorm(100), y= x + rnorm(100,0, 0.1), z = x + y + rnorm(100, 0, 0.1))
ggpairs(df, columnLabels = expression(alpha, beta, gamma))
```
![screen shot 2016-11-03 at 11 54 46 am](https://cloud.githubusercontent.com/assets/93231/19973703/5b9a0c26-a1bc-11e6-8714-2bfa06237f7e.png)