### PR TITLE
Add labeller argument to ggmatrix() and ggpairs()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 GGally 1.2.9.9999
 -----------------
 
+`ggmatrix` and `ggpairs` - allow custom labellers for facet labels.
+
+* Allow `labeller = "label_parsed"` to label pairs plots with plotmath expressions.
+
 `ggmatrix.print` - massive update!
 
 * Now prints with a ggplot2 facet'ed structure

--- a/R/ggmatrix.R
+++ b/R/ggmatrix.R
@@ -16,6 +16,7 @@
 #' @param byrow boolean that determines whether the plots should be ordered by row or by column
 #' @param data data set using. This is the data to be used in place of 'ggally_data' if the plot is a string to be evaluated at print time
 #' @param gg ggplot2 theme objects to be applied to every plot
+#' @param labeller labeller for facets. See \code{\link[ggplot2]{labellers}}. Common values are \code{"label_value"} (default) and \code{"label_parsed"}.
 #' @template ggmatrix-legend-param
 #' @keywords hplot
 #' @author Barret Schloerke \email{schloerke@@gmail.com}
@@ -65,7 +66,8 @@ ggmatrix <- function(
   yProportions = NULL,
   data = NULL,
   gg = NULL,
-  legend = NULL
+  legend = NULL,
+  labeller = 'label_value'
 ) {
 
   if (!is.list(plots)) {
@@ -93,6 +95,7 @@ ggmatrix <- function(
     xProportions = xProportions,
     yProportions = yProportions,
     legend = legend,
+    labeller = labeller,
     gg = gg,
     nrow = nrow,
     ncol = ncol,

--- a/R/ggmatrix_gtable.R
+++ b/R/ggmatrix_gtable.R
@@ -35,6 +35,8 @@ ggmatrix_gtable <- function(
     # pb$tick(tokens = list(plot_i = 1, plot_j = 1))
   }
 
+  labeller <-  pm$labeller
+  if (is.null(labeller)) labeller <-  'label_value'
 
   # make a fake facet grid to fill in with proper plot panels
   fake_data <- expand.grid(
@@ -47,7 +49,7 @@ ggmatrix_gtable <- function(
   # make the smallest plot possible so the guts may be replaced
   pm_fake <- ggplot(fake_data, mapping = aes_("x", "y")) +
     geom_point() +
-    facet_grid(Var2 ~ Var1) + # make the 'fake' strips for x and y titles
+    facet_grid(Var2 ~ Var1, labeller = labeller) + # make the 'fake' strips for x and y titles
     labs(x = pm$xlab, y = pm$ylab) # remove both x and y titles
 
   # add all custom ggplot2 things

--- a/R/ggpairs.R
+++ b/R/ggpairs.R
@@ -618,6 +618,7 @@ ggduo <- function(
 #' @template ggmatrix-legend-param
 #' @param cardinality_threshold maximum number of levels allowed in a charcter / factor column.  Set this value to NULL to not check factor columns. Defaults to 15
 #' @param legends deprecated
+#' @param labeller labeller for facets. See \code{\link[ggplot2]{labellers}}. Common values are \code{"label_value"} (default) and \code{"label_parsed"}.
 #' @keywords hplot
 #' @import ggplot2
 #' @references John W Emerson, Walton A Green, Barret Schloerke, Jason Crowley, Dianne Cook, Heike Hofmann, Hadley Wickham. The Generalized Pairs Plot. Journal of Computational and Graphical Statistics, vol. 22, no. 1, pp. 79-91, 2012.
@@ -681,6 +682,13 @@ ggduo <- function(
 #' pm <- ggpairs(tips[, 1:3], axisLabels="none")
 #' p_(pm)
 #'
+#' ## Facet Label Variations
+#' #  Default:
+#' df <- tibble::data_frame(x = rnorm(100), y = a + rnorm(100, 0, 0.1), c = sqrt(x^2 +  y^2))
+#' ggpairs(df, columnLabels = c("alpha[foo]", "alpha[bar]", "sqrt(alpha[foo]^2 + alpha[bar]^2)"))
+#' #  Parsed labels:
+#' ggpairs(df, columnLabels = c("alpha[foo]", "alpha[bar]", "sqrt(alpha[foo]^2 + alpha[bar]^2)"), labeller = "label_parsed")
+#'
 #' ## Plot Insertion Example
 #' custom_car <- ggpairs(mtcars[, c("mpg", "wt", "cyl")], upper = "blank", title = "Custom Example")
 #' # ggplot example taken from example(geom_text)
@@ -722,7 +730,8 @@ ggpairs <- function(
   showStrips = NULL,
   legend = NULL,
   cardinality_threshold = 15,
-  legends = stop("deprecated")
+  legends = stop("deprecated"),
+  labeller = 'label_value'
 ){
 
   warn_deprecated(!missing(legends), "legends")
@@ -817,7 +826,8 @@ ggpairs <- function(
     ylab = ylab,
     data = data,
     gg = NULL,
-    legend = legend
+    legend = legend,
+    labeller = labeller
   )
 
   plotMatrix

--- a/R/ggpairs.R
+++ b/R/ggpairs.R
@@ -684,7 +684,7 @@ ggduo <- function(
 #'
 #' ## Facet Label Variations
 #' #  Default:
-#' df <- tibble::data_frame(x = rnorm(100), y = a + rnorm(100, 0, 0.1), c = sqrt(x^2 +  y^2))
+#' df <- tibble::data_frame(x = rnorm(100), y = x + rnorm(100, 0, 0.1), c = sqrt(x^2 +  y^2))
 #' ggpairs(df, columnLabels = c("alpha[foo]", "alpha[bar]", "sqrt(alpha[foo]^2 + alpha[bar]^2)"))
 #' #  Parsed labels:
 #' ggpairs(df, columnLabels = c("alpha[foo]", "alpha[bar]", "sqrt(alpha[foo]^2 + alpha[bar]^2)"), labeller = "label_parsed")

--- a/man/ggmatrix.Rd
+++ b/man/ggmatrix.Rd
@@ -9,7 +9,7 @@ ggmatrix(plots, nrow, ncol, xAxisLabels = NULL, yAxisLabels = NULL,
   showStrips = NULL, showAxisPlotLabels = TRUE,
   showXAxisPlotLabels = TRUE, showYAxisPlotLabels = TRUE,
   xProportions = NULL, yProportions = NULL, data = NULL, gg = NULL,
-  legend = NULL)
+  legend = NULL, labeller = "label_value")
 }
 \arguments{
 \item{plots}{list of plots to be put into matrix}
@@ -33,6 +33,8 @@ ggmatrix(plots, nrow, ncol, xAxisLabels = NULL, yAxisLabels = NULL,
 \item{gg}{ggplot2 theme objects to be applied to every plot}
 
 \item{legend}{May be the two objects described below or the default \code{NULL} value.  The legend position can be moved by using ggplot2's theme element \code{pm + theme(legend.position = "bottom")} \describe{\item{a numeric vector of length 2}{provides the location of the plot to use the legend for the plot matrix's legend. Such as \code{legend = c(3,5)} which will use the legend from the plot in the third row and fifth column}\item{a single numeric value}{provides the location of a plot according to the display order. Such as \code{legend = 3} in a plot matrix with 2 rows and 5 columns displayed by column will return the plot in position \code{c(1,2)}}\item{a object from \code{\link{grab_legend}()}}{a predetermined plot legend that will be displayed directly}}}
+
+\item{labeller}{labeller for facets. See \code{\link[ggplot2]{labellers}}. Common values are \code{"label_value"} (default) and \code{"label_parsed"}.}
 }
 \description{
 Make a generic matrix of ggplot2 plots.

--- a/man/ggpairs.Rd
+++ b/man/ggpairs.Rd
@@ -11,7 +11,8 @@ ggpairs(data, mapping = NULL, columns = 1:ncol(data), title = NULL,
   "densityDiag", discrete = "barDiag", na = "naDiag"), params = NULL, ...,
   xlab = NULL, ylab = NULL, axisLabels = c("show", "internal", "none"),
   columnLabels = colnames(data[columns]), showStrips = NULL,
-  legend = NULL, cardinality_threshold = 15, legends = stop("deprecated"))
+  legend = NULL, cardinality_threshold = 15, legends = stop("deprecated"),
+  labeller = "label_value")
 }
 \arguments{
 \item{data}{data set using.  Can have both numerical and categorical data.}
@@ -43,6 +44,8 @@ ggpairs(data, mapping = NULL, columns = 1:ncol(data), title = NULL,
 \item{cardinality_threshold}{maximum number of levels allowed in a charcter / factor column.  Set this value to NULL to not check factor columns. Defaults to 15}
 
 \item{legends}{deprecated}
+
+\item{labeller}{labeller for facets. See \code{\link[ggplot2]{labellers}}. Common values are \code{"label_value"} (default) and \code{"label_parsed"}.}
 }
 \value{
 ggpair object that if called, will print
@@ -128,6 +131,13 @@ p_(pm)
 # Only Variable Labels on the outside (no axis labels)
 pm <- ggpairs(tips[, 1:3], axisLabels="none")
 p_(pm)
+
+## Facet Label Variations
+#  Default:
+df <- tibble::data_frame(x = rnorm(100), y = a + rnorm(100, 0, 0.1), c = sqrt(x^2 +  y^2))
+ggpairs(df, columnLabels = c("alpha[foo]", "alpha[bar]", "sqrt(alpha[foo]^2 + alpha[bar]^2)"))
+#  Parsed labels:
+ggpairs(df, columnLabels = c("alpha[foo]", "alpha[bar]", "sqrt(alpha[foo]^2 + alpha[bar]^2)"), labeller = "label_parsed")
 
 ## Plot Insertion Example
 custom_car <- ggpairs(mtcars[, c("mpg", "wt", "cyl")], upper = "blank", title = "Custom Example")


### PR DESCRIPTION
Here is an alternate approach to managing expressions in column labels. This one is more in the spirit of ggplot2 and is more flexible than assigning expressions directly to the argument `columnLabels`.

Here, `columnLabels` must be a character vector, but the user can give `labeller` as an argument (e.g., `labeller = "label_parsed"`) 