### PR TITLE
Allow to use non-factor "color" for `ggscatmat`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(
     person("Edwin", "Thoen", role = "aut", email = "edwinthoen@gmail.com", comment = "ggsurv"),
     person("Amos", "Elberg", role = "aut", email = "amos.elberg@gmail.com", comment = "ggnetworkmap"),
     person("Joseph", "Larmarange", role = "aut", email = "joseph@larmarange.net", comment = "ggcoef"),
-    person("Ott", "Toomet", role = "aut", email = "otoomet@gmail.com", comment = "ggscatmat"))
+    person("Ott", "Toomet", role = "ctb", email = "otoomet@gmail.com"))
 Description:
     The R package 'ggplot2' is a plotting system based on the grammar of graphics.
     'GGally' extends 'ggplot2' by adding several functions

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: GGally
-Version: 1.4.0
+Version: 1.4.1
 License: GPL (>= 2.0)
 Title: Extension to 'ggplot2'
 Type: Package
@@ -17,7 +17,8 @@ Authors@R: c(
     person("Moritz", "Marbach", role = "aut", email = "mmarbach@mail.uni-mannheim.de", comment = "ggnet, ggnet2"),
     person("Edwin", "Thoen", role = "aut", email = "edwinthoen@gmail.com", comment = "ggsurv"),
     person("Amos", "Elberg", role = "aut", email = "amos.elberg@gmail.com", comment = "ggnetworkmap"),
-    person("Joseph", "Larmarange", role = "aut", email = "joseph@larmarange.net", comment = "ggcoef"))
+    person("Joseph", "Larmarange", role = "aut", email = "joseph@larmarange.net", comment = "ggcoef"),
+    person("Ott", "Toomet", role = "aut", email = "otoomet@gmail.com", comment = "ggscatmat"))
 Description:
     The R package 'ggplot2' is a plotting system based on the grammar of graphics.
     'GGally' extends 'ggplot2' by adding several functions

--- a/R/ggscatmat.R
+++ b/R/ggscatmat.R
@@ -212,18 +212,20 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
   if (ncol(dn) == 0) {
     stop("All of your variables are factors. Need numeric variables to make scatterplot matrix.")
   } else {
-    ltdata.new <- lowertriangle(data, columns = columns, color = color)
+     ltdata.new <- lowertriangle(data, columns = columns, color = color)
+     ## set up the plot
     r <- ggplot(ltdata.new, mapping = aes_string(x = "xvalue", y = "yvalue")) +
       theme(axis.title.x = element_blank(), axis.title.y = element_blank()) +
       facet_grid(ylab ~ xlab, scales = "free") +
       theme(aspect.ratio = 1)
     if (is.null(color)) {
+       ## b/w version
       densities <- do.call("rbind", lapply(1:ncol(dn), function(i) {
         data.frame(xlab = names(dn)[i], ylab = names(dn)[i],
                    x = dn[, i])
       }))
       for (m in 1:ncol(dn)) {
-        j <- subset(densities, xlab == names(dn)[m])
+         j <- subset(densities, xlab == names(dn)[m])
         r <- r + stat_density(
           aes(
             x = x,
@@ -231,26 +233,30 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
           ),
           data = j, position = "identity", geom = "line", color = "black")
       }
+       ## add b/w points
       r <- r + geom_point(alpha = alpha, na.rm = TRUE)
       return(r)
     } else {
+       ## do the colored version
       densities <- do.call("rbind", lapply(1:ncol(dn), function(i) {
         data.frame(xlab = names(dn)[i], ylab = names(dn)[i],
                    x = dn[, i], colorcolumn = data[, which(colnames(data) == color)])
       }))
       for (m in 1:ncol(dn)) {
-        j <- subset(densities, xlab == names(dn)[m])
+         j <- subset(densities, xlab == names(dn)[m])
         r <- r +
+                           # r is the facet grid plot
           stat_density(
             aes_string(
-              x = "x", y = "..scaled.. * diff(range(x)) + min(x)",
-              colour = "colorcolumn"
+               x = "x", y = "..scaled.. * diff(range(x)) + min(x)",
+               colour = "colorcolumn"
             ),
             data = j,
             position = "identity",
             geom = "line"
           )
       }
+       ## add color points
       r <- r +
         geom_point(
           data = ltdata.new,
@@ -271,7 +277,8 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
 #' @export
 #' @param data a data matrix. Should contain numerical (continuous) data.
 #' @param columns an option to choose the column to be used in the raw dataset. Defaults to \code{1:ncol(data)}.
-#' @param color an option to group the dataset by the factor variable and color them by different colors. Defaults to \code{NULL}.
+#' @param color an option to group the dataset by the factor variable and color them by different colors. Defaults to \code{NULL}, i.e. no coloring.
+#'    Converted to a factor.
 #' @param alpha an option to set the transparency in scatterplots for large data. Defaults to \code{1}.
 #' @param corMethod method argument supplied to \code{\link[stats]{cor}}
 #' @author Mengjia Ni, Di Cook \email{dicook@@monash.edu}
@@ -280,7 +287,14 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
 #' ggscatmat(flea, columns = 2:4)
 #' ggscatmat(flea, columns = 2:4, color = "species")
 ggscatmat <- function(data, columns = 1:ncol(data), color = NULL, alpha = 1, corMethod = "pearson"){
-
+  ## if 'color' is not a factor, mold it into one
+  if(!is.null(color)) {
+     if(is.null(data[[color]])) {
+        stop(paste0("Non-existent column <", color, "> requested"))
+     }
+     data[[color]] <- factor(data[[color]])
+  }
+  ##
   data <- upgrade_scatmat_data(data)
   data.choose <- data[columns]
   dn <- data.choose[sapply(data.choose, is.numeric)]

--- a/R/ggscatmat.R
+++ b/R/ggscatmat.R
@@ -225,7 +225,7 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
                    x = dn[, i])
       }))
       for (m in 1:ncol(dn)) {
-         j <- subset(densities, xlab == names(dn)[m])
+        j <- subset(densities, xlab == names(dn)[m])
         r <- r + stat_density(
           aes(
             x = x,
@@ -243,20 +243,20 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
                    x = dn[, i], colorcolumn = data[, which(colnames(data) == color)])
       }))
       for (m in 1:ncol(dn)) {
-         j <- subset(densities, xlab == names(dn)[m])
+        j <- subset(densities, xlab == names(dn)[m])
         r <- r +
                            # r is the facet grid plot
           stat_density(
             aes_string(
-               x = "x", y = "..scaled.. * diff(range(x)) + min(x)",
-               colour = "colorcolumn"
+              x = "x", y = "..scaled.. * diff(range(x)) + min(x)",
+              colour = "colorcolumn"
             ),
             data = j,
             position = "identity",
             geom = "line"
           )
       }
-       ## add color points
+      ## add color points
       r <- r +
         geom_point(
           data = ltdata.new,
@@ -277,8 +277,8 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
 #' @export
 #' @param data a data matrix. Should contain numerical (continuous) data.
 #' @param columns an option to choose the column to be used in the raw dataset. Defaults to \code{1:ncol(data)}.
-#' @param color an option to group the dataset by the factor variable and color them by different colors. Defaults to \code{NULL}, i.e. no coloring.
-#'    Converted to a factor.
+#' @param color an option to group the dataset by the factor variable and color them by different colors. 
+#'   Defaults to \code{NULL}, i.e. no coloring. If supplied, it will be converted to a factor.
 #' @param alpha an option to set the transparency in scatterplots for large data. Defaults to \code{1}.
 #' @param corMethod method argument supplied to \code{\link[stats]{cor}}
 #' @author Mengjia Ni, Di Cook \email{dicook@@monash.edu}
@@ -288,11 +288,11 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
 #' ggscatmat(flea, columns = 2:4, color = "species")
 ggscatmat <- function(data, columns = 1:ncol(data), color = NULL, alpha = 1, corMethod = "pearson"){
   ## if 'color' is not a factor, mold it into one
-  if(!is.null(color)) {
-     if(is.null(data[[color]])) {
+  if (!is.null(color)) {
+     if (is.null(data[[color]])) {
         stop(paste0("Non-existent column <", color, "> requested"))
      }
-     data[[color]] <- factor(data[[color]])
+     data[[color]] <- as.factor(data[[color]])
   }
   ##
   data <- upgrade_scatmat_data(data)


### PR DESCRIPTION
This small PR converts the `color` variable in data to a factor in `ggscatmat` function.  It also does a few checks.  So one can use non-factor numeric variables to plot the dots in different colors.  CMD check passed.

Contains two commits: one for code, the other for udates in DESCRIPTION

Usage case: the 1/0 indicator has to be a number in order to be able to compute correlation, and hence would like not to convert it just for the plot.