### PR TITLE
Double Axes Support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: GGally
-Version: 1.4.0
+Version: 1.4.0.9000
 License: GPL (>= 2.0)
 Title: Extension to 'ggplot2'
 Type: Package


### PR DESCRIPTION
Fixes #298 

``` r
library(ggplot2)
#> Registered S3 methods overwritten by 'ggplot2':
#>   method         from 
#>   [.quosures     rlang
#>   c.quosures     rlang
#>   print.quosures rlang
library(GGally)
#> Registered S3 method overwritten by 'GGally':
#>   method from   
#>   +.gg   ggplot2

ggpairs(
  iris, 
  1:3, 
  upper = list(
    continuous = function(data, mapping, ...) { 
      ggplot(data, mapping) + 
      geom_point() + 
      scale_x_continuous(sec.axis = sec_axis(~.+10)) + 
      scale_y_continuous(sec.axis = sec_axis(~.+10))
    } 
  ) 
) + 
  theme(strip.placement = "outside")
```

![](https://i.imgur.com/1BrESwt.png)

<sup>Created on 2019-05-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>