### PR TITLE
ggally_cor no grid

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Suggests:
     testthat,
     crosstalk
 Roxygen: list(markdown = FALSE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 VignetteBuilder: packagedocs
 SystemRequirements: openssl
 Encoding: UTF-8

--- a/R/gg-plots.R
+++ b/R/gg-plots.R
@@ -211,6 +211,7 @@ ggally_density <- function(data, mapping, ...){
 #' @param corAlignPercent deprecated. Use parameter \code{alignPercent}
 #' @param corMethod deprecated. Use parameter \code{method}
 #' @param corUse deprecated. Use parameter \code{use}
+#' @param themeVoid void theme, removes grid lines and axes from plot if TRUE
 #' @param ... other arguments being supplied to geom_text
 #' @author Barret Schloerke \email{schloerke@@gmail.com}
 #' @importFrom stats complete.cases cor
@@ -230,12 +231,20 @@ ggally_density <- function(data, mapping, ...){
 #'    mapping = ggplot2::aes_string(x = "total_bill", y = "tip", color = "sex"),
 #'    size = 5
 #'  )
+#'
+#'  ggally_cor(
+#'    tips,
+#'    mapping = ggplot2::aes_string(x = "total_bill", y = "tip", color = "sex"),
+#'    size = 5,
+#'    themeVoid=TRUE
+#'  )
 ggally_cor <- function(
   data,
   mapping,
   alignPercent = 0.6,
   method = "pearson", use = "complete.obs",
   corAlignPercent = NULL, corMethod = NULL, corUse = NULL,
+  themeVoid=FALSE,
   ...
 ){
 
@@ -403,9 +412,7 @@ ggally_cor <- function(
       yrange  = yrange,
       color   = "black",
       ...
-    ) +
-    #element_bw() +
-    theme(legend.position = "none")
+    )
 
     xPos <- rep(alignPercent, nrow(cord)) * diff(xrange) + min(xrange, na.rm = TRUE)
     yPos <- seq(
@@ -434,8 +441,6 @@ ggally_cor <- function(
       ...
 
     )
-
-    p
   } else {
     # calculate variable ranges so the gridlines line up
     xmin <- min(xVal, na.rm = TRUE)
@@ -460,12 +465,13 @@ ggally_cor <- function(
       xrange = xrange,
       yrange = yrange,
       ...
-    ) +
-    #element_bw() +
-    theme(legend.position = "none")
-
-    p
+    )
   }
+  if(themeVoid) {
+    p <- p + theme_void()
+  }
+  p +
+    theme(legend.position = "none")
 }
 
 

--- a/R/gg-plots.R
+++ b/R/gg-plots.R
@@ -211,6 +211,7 @@ ggally_density <- function(data, mapping, ...){
 #' @param corAlignPercent deprecated. Use parameter \code{alignPercent}
 #' @param corMethod deprecated. Use parameter \code{method}
 #' @param corUse deprecated. Use parameter \code{use}
+#' @param displayGrid if TRUE, display aligned panel gridlines
 #' @param ... other arguments being supplied to geom_text
 #' @author Barret Schloerke \email{schloerke@@gmail.com}
 #' @importFrom stats complete.cases cor
@@ -219,6 +220,8 @@ ggally_density <- function(data, mapping, ...){
 #' @examples
 #'  data(tips, package = "reshape")
 #'  ggally_cor(tips, mapping = ggplot2::aes_string(x = "total_bill", y = "tip"))
+#'  ggally_cor(tips, mapping = ggplot2::aes_string(x = "total_bill", y = "tip"),
+#'             displayGrid=FALSE)
 #'  ggally_cor(
 #'    tips,
 #'    mapping = ggplot2::aes(x = total_bill, y = tip),
@@ -237,6 +240,7 @@ ggally_cor <- function(
   alignPercent = 0.6,
   method = "pearson", use = "complete.obs",
   corAlignPercent = NULL, corMethod = NULL, corUse = NULL,
+  displayGrid = TRUE,
   ...
 ){
 
@@ -459,11 +463,13 @@ ggally_cor <- function(
       ...
     )
   }
-  p +
-    theme(legend.position = "none",
-          panel.grid.major = element_blank(),
+  if (!displayGrid) {
+    p <- p +
+    theme(panel.grid.major = element_blank(),
           panel.grid.minor = element_blank()
           )
+  }
+  p + theme(legend.position = "none")
 }
 
 

--- a/R/gg-plots.R
+++ b/R/gg-plots.R
@@ -211,7 +211,6 @@ ggally_density <- function(data, mapping, ...){
 #' @param corAlignPercent deprecated. Use parameter \code{alignPercent}
 #' @param corMethod deprecated. Use parameter \code{method}
 #' @param corUse deprecated. Use parameter \code{use}
-#' @param themeVoid void theme, removes grid lines and axes from plot if TRUE
 #' @param ... other arguments being supplied to geom_text
 #' @author Barret Schloerke \email{schloerke@@gmail.com}
 #' @importFrom stats complete.cases cor
@@ -232,19 +231,12 @@ ggally_density <- function(data, mapping, ...){
 #'    size = 5
 #'  )
 #'
-#'  ggally_cor(
-#'    tips,
-#'    mapping = ggplot2::aes_string(x = "total_bill", y = "tip", color = "sex"),
-#'    size = 5,
-#'    themeVoid=TRUE
-#'  )
 ggally_cor <- function(
   data,
   mapping,
   alignPercent = 0.6,
   method = "pearson", use = "complete.obs",
   corAlignPercent = NULL, corMethod = NULL, corUse = NULL,
-  themeVoid=FALSE,
   ...
 ){
 
@@ -467,11 +459,11 @@ ggally_cor <- function(
       ...
     )
   }
-  if(themeVoid) {
-    p <- p + theme_void()
-  }
   p +
-    theme(legend.position = "none")
+    theme(legend.position = "none",
+          panel.grid.major = element_blank(),
+          panel.grid.minor = element_blank()
+          )
 }
 
 

--- a/R/ggpairs.R
+++ b/R/ggpairs.R
@@ -724,6 +724,10 @@ ggduo <- function(
 #' # no warning displayed with user supplied function
 #' pm <- ggpairs(tips, 2:3, lower = list(combo = wrap(ggally_facethist, binwidth = 0.5)))
 #' p_(pm)
+#'
+#' ## Remove panel grid lines from correlation plots
+#' ggpairs(flea, columns = 2:4,
+#'         upper=list(continuous=wrap(ggally_cor,themeVoid=TRUE)))
 ggpairs <- function(
   data,
   mapping = NULL,

--- a/R/ggpairs.R
+++ b/R/ggpairs.R
@@ -725,9 +725,6 @@ ggduo <- function(
 #' pm <- ggpairs(tips, 2:3, lower = list(combo = wrap(ggally_facethist, binwidth = 0.5)))
 #' p_(pm)
 #'
-#' ## Remove panel grid lines from correlation plots
-#' ggpairs(flea, columns = 2:4,
-#'         upper=list(continuous=wrap(ggally_cor,themeVoid=TRUE)))
 ggpairs <- function(
   data,
   mapping = NULL,

--- a/R/ggpairs.R
+++ b/R/ggpairs.R
@@ -725,6 +725,10 @@ ggduo <- function(
 #' pm <- ggpairs(tips, 2:3, lower = list(combo = wrap(ggally_facethist, binwidth = 0.5)))
 #' p_(pm)
 #'
+#' ## Remove panel grid lines from correlation plots
+#' ggpairs(flea, columns = 2:4,
+#'         upper=list(continuous=wrap(ggally_cor,displayGrid=FALSE)))
+#'
 ggpairs <- function(
   data,
   mapping = NULL,

--- a/man/ggally_cor.Rd
+++ b/man/ggally_cor.Rd
@@ -13,7 +13,6 @@ ggally_cor(
   corAlignPercent = NULL,
   corMethod = NULL,
   corUse = NULL,
-  themeVoid = FALSE,
   ...
 )
 }
@@ -33,8 +32,6 @@ ggally_cor(
 \item{corMethod}{deprecated. Use parameter \code{method}}
 
 \item{corUse}{deprecated. Use parameter \code{use}}
-
-\item{themeVoid}{void theme, removes grid lines and axes from plot if TRUE}
 
 \item{...}{other arguments being supplied to geom_text}
 }
@@ -56,12 +53,6 @@ Estimate correlation from the given data.
    size = 5
  )
 
- ggally_cor(
-   tips,
-   mapping = ggplot2::aes_string(x = "total_bill", y = "tip", color = "sex"),
-   size = 5,
-   themeVoid=TRUE
- )
 }
 \author{
 Barret Schloerke \email{schloerke@gmail.com}

--- a/man/ggally_cor.Rd
+++ b/man/ggally_cor.Rd
@@ -13,6 +13,7 @@ ggally_cor(
   corAlignPercent = NULL,
   corMethod = NULL,
   corUse = NULL,
+  themeVoid = FALSE,
   ...
 )
 }
@@ -33,6 +34,8 @@ ggally_cor(
 
 \item{corUse}{deprecated. Use parameter \code{use}}
 
+\item{themeVoid}{void theme, removes grid lines and axes from plot if TRUE}
+
 \item{...}{other arguments being supplied to geom_text}
 }
 \description{
@@ -51,6 +54,13 @@ Estimate correlation from the given data.
    tips,
    mapping = ggplot2::aes_string(x = "total_bill", y = "tip", color = "sex"),
    size = 5
+ )
+
+ ggally_cor(
+   tips,
+   mapping = ggplot2::aes_string(x = "total_bill", y = "tip", color = "sex"),
+   size = 5,
+   themeVoid=TRUE
  )
 }
 \author{

--- a/man/ggally_cor.Rd
+++ b/man/ggally_cor.Rd
@@ -13,6 +13,7 @@ ggally_cor(
   corAlignPercent = NULL,
   corMethod = NULL,
   corUse = NULL,
+  displayGrid = TRUE,
   ...
 )
 }
@@ -33,6 +34,8 @@ ggally_cor(
 
 \item{corUse}{deprecated. Use parameter \code{use}}
 
+\item{displayGrid}{if TRUE, display aligned panel gridlines}
+
 \item{...}{other arguments being supplied to geom_text}
 }
 \description{
@@ -41,6 +44,8 @@ Estimate correlation from the given data.
 \examples{
  data(tips, package = "reshape")
  ggally_cor(tips, mapping = ggplot2::aes_string(x = "total_bill", y = "tip"))
+ ggally_cor(tips, mapping = ggplot2::aes_string(x = "total_bill", y = "tip"),
+            displayGrid=FALSE)
  ggally_cor(
    tips,
    mapping = ggplot2::aes(x = total_bill, y = tip),

--- a/man/ggpairs.Rd
+++ b/man/ggpairs.Rd
@@ -194,6 +194,10 @@ p_(pm)
 # no warning displayed with user supplied function
 pm <- ggpairs(tips, 2:3, lower = list(combo = wrap(ggally_facethist, binwidth = 0.5)))
 p_(pm)
+
+## Remove panel grid lines from correlation plots
+ggpairs(flea, columns = 2:4,
+        upper=list(continuous=wrap(ggally_cor,themeVoid=TRUE)))
 }
 \references{
 John W Emerson, Walton A Green, Barret Schloerke, Jason Crowley, Dianne Cook, Heike Hofmann, Hadley Wickham. The Generalized Pairs Plot. Journal of Computational and Graphical Statistics, vol. 22, no. 1, pp. 79-91, 2012.

--- a/man/ggpairs.Rd
+++ b/man/ggpairs.Rd
@@ -195,6 +195,10 @@ p_(pm)
 pm <- ggpairs(tips, 2:3, lower = list(combo = wrap(ggally_facethist, binwidth = 0.5)))
 p_(pm)
 
+## Remove panel grid lines from correlation plots
+ggpairs(flea, columns = 2:4,
+        upper=list(continuous=wrap(ggally_cor,displayGrid=FALSE)))
+
 }
 \references{
 John W Emerson, Walton A Green, Barret Schloerke, Jason Crowley, Dianne Cook, Heike Hofmann, Hadley Wickham. The Generalized Pairs Plot. Journal of Computational and Graphical Statistics, vol. 22, no. 1, pp. 79-91, 2012.

--- a/man/ggpairs.Rd
+++ b/man/ggpairs.Rd
@@ -195,9 +195,6 @@ p_(pm)
 pm <- ggpairs(tips, 2:3, lower = list(combo = wrap(ggally_facethist, binwidth = 0.5)))
 p_(pm)
 
-## Remove panel grid lines from correlation plots
-ggpairs(flea, columns = 2:4,
-        upper=list(continuous=wrap(ggally_cor,themeVoid=TRUE)))
 }
 \references{
 John W Emerson, Walton A Green, Barret Schloerke, Jason Crowley, Dianne Cook, Heike Hofmann, Hadley Wickham. The Generalized Pairs Plot. Journal of Computational and Graphical Statistics, vol. 22, no. 1, pp. 79-91, 2012.


### PR DESCRIPTION
This removes gridlines by default from `ggally_cor`, by incorporating `theme(panel.grid.major=element_blank())` into function call.

Gridlines on a plot, that only contains text for a correlation coefficeint, seems to me only to add visual noise. The plot is clearer and better without.

Users can still add gridlines back in using `ggpairs (...) + theme(panel.grid.major=element_line())`. That possibility (but for removing) was suggested in [a brief introduction to ggpairs](https://www.blopig.com/blog/2019/06/a-brief-introduction-to-ggpairs/)

In addition to making the Oxford protein informatics group solution the default, this answers stack overflow issue, [ggpairs() correlation values without gridlines](https://stackoverflow.com/questions/48104455/ggpairs-correlation-values-without-gridlines), also [earlier](https://stackoverflow.com/questions/21810675/ggallyggpairs-plot-without-gridlines-when-plotting-correlation-coefficient).

Thanks for making and sharing this great package! I use ggpairs frequently. 
