### PR TITLE
set se_fit to TRUE in augment call

### DIFF
--- a/R/ggnostic.R
+++ b/R/ggnostic.R
@@ -37,7 +37,7 @@ broomify <- function(model, lmStars = TRUE) {
 
   broom_glance_info  <- broom::glance(model)
   broom_tidy_coef    <- broom::tidy(model)
-  broom_augment_rows <- broom::augment(model)
+  broom_augment_rows <- broom::augment(model, se_fit = TRUE)
   attr(broom_augment_rows, "broom_glance") <- broom_glance_info
   attr(broom_augment_rows, "broom_tidy") <- broom_tidy_coef
   attr(broom_augment_rows, "var_x") <- model_beta_variables(data = broom_augment_rows)


### PR DESCRIPTION
Hi there!

The broom dev team just ran reverse dependency checks on the upcoming broom 0.7.0 release and found new errors/test failures for the CRAN version of this package. I've pasted the results below, which seem to result from our decision to require the user to explicitly request the `.se.fit` column through the `se_fit` argument in `augment` methods since it is sometimes computationally intensive.


*   checking examples ... ERROR
    ```
    Running examples in ‘GGally-Ex.R’ failed
    The error most likely occurred in:
    
    > ### Name: ggally_nostic_se_fit
    > ### Title: ggnostic - fitted value standard error
    > ### Aliases: ggally_nostic_se_fit
    > 
    > ### ** Examples
    > 
    > dt <- broomify(stats::lm(mpg ~ wt + qsec + am, data = mtcars))
    > ggally_nostic_se_fit(dt, ggplot2::aes(wt, .se.fit))
    Error in FUN(X[[i]], ...) : object '.se.fit' not found
    Calls: <Anonymous> ... <Anonymous> -> f -> scales_add_defaults -> lapply -> FUN
    Execution halted
    ```

*   checking tests ...
    ```
     ERROR
    Running the tests in ‘tests/testthat.R’ failed.
    Last 13 lines of output:
      > 
      > test_check("GGally")
      [31m──[39m [31m1. Error: ggnostic mtcars (@test-ggnostic.R#64) [39m [31m────────────────────────────[39m
      Columns in 'columnsY' not found in data: c('.se.fit'). Choices: c('.rownames', 'mpg', 'wt', 'qsec', 'am', '.fitted', '.resid', '.std.resid', '.hat', '.sigma', '.cooksd')
      [1mBacktrace:[22m
      [90m 1. [39mGGally::ggnostic(...)
      [90m 2. [39mGGally::ggduo(...)
      [90m 3. [39mGGally:::fix_column_values(...)
      
      ══ testthat results  ═══════════════════════════════════════════════════════════
      [ OK: 757 | SKIPPED: 0 | WARNINGS: 2 | FAILED: 1 ]
      1. Error: ggnostic mtcars (@test-ggnostic.R#64) 
      
      Error: testthat unit tests failed
      Execution halted
    ```

You should be good to go with the new broom release once this PR is merged.🙂

