### PR TITLE
Preserve factor ordering in ggscatmat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,7 @@ GGally (development version)
 
 `ggscatmat()`
 * `lowertriangle()` now preallocates it's memory usage for a 2-5x speed improvement. (@vlepori, #328)
+* Fixed `facet`'ing error where the factor order was not preserved. This error caused the facets to be alphabetically sorted, cause plots to appear in unexpected locations. (#355)
 
 Website
 * Updated to use `pkgdown` (#335)

--- a/R/ggscatmat.R
+++ b/R/ggscatmat.R
@@ -231,7 +231,7 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
        ## b/w version
       densities <- do.call("rbind", lapply(1:ncol(dn), function(i) {
         data.frame(xlab = names(dn)[i], ylab = names(dn)[i],
-                   x = dn[, i])
+                   x = dn[, i], stringsAsFactors = TRUE)
       }))
       for (m in 1:ncol(dn)) {
         j <- subset(densities, xlab == names(dn)[m])
@@ -249,7 +249,8 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
        ## do the colored version
       densities <- do.call("rbind", lapply(1:ncol(dn), function(i) {
         data.frame(xlab = names(dn)[i], ylab = names(dn)[i],
-                   x = dn[, i], colorcolumn = data[, which(colnames(data) == color)])
+                   x = dn[, i], colorcolumn = data[, which(colnames(data) == color)],
+                   stringsAsFactors = TRUE)
       }))
       for (m in 1:ncol(dn)) {
         j <- subset(densities, xlab == names(dn)[m])
@@ -286,7 +287,7 @@ scatmat <- function(data, columns=1:ncol(data), color=NULL, alpha=1) {
 #' @export
 #' @param data a data matrix. Should contain numerical (continuous) data.
 #' @param columns an option to choose the column to be used in the raw dataset. Defaults to \code{1:ncol(data)}.
-#' @param color an option to group the dataset by the factor variable and color them by different colors. 
+#' @param color an option to group the dataset by the factor variable and color them by different colors.
 #'   Defaults to \code{NULL}, i.e. no coloring. If supplied, it will be converted to a factor.
 #' @param alpha an option to set the transparency in scatterplots for large data. Defaults to \code{1}.
 #' @param corMethod method argument supplied to \code{\link[stats]{cor}}

--- a/man/ggscatmat.Rd
+++ b/man/ggscatmat.Rd
@@ -17,7 +17,7 @@ ggscatmat(
 
 \item{columns}{an option to choose the column to be used in the raw dataset. Defaults to \code{1:ncol(data)}.}
 
-\item{color}{an option to group the dataset by the factor variable and color them by different colors. 
+\item{color}{an option to group the dataset by the factor variable and color them by different colors.
 Defaults to \code{NULL}, i.e. no coloring. If supplied, it will be converted to a factor.}
 
 \item{alpha}{an option to set the transparency in scatterplots for large data. Defaults to \code{1}.}


### PR DESCRIPTION
Fixes https://github.com/ggobi/ggally/issues/329

https://cran.r-project.org/doc/manuals/r-devel/NEWS.html
> R now uses a stringsAsFactors = FALSE default, and hence by default no longer converts strings to factors in calls to data.frame() and read.table().

When the stat_density was being added to the plot, the stat_density data was not a factor. This caused the original data to become "un-factored" (which caused the alphabetical sorting). 

Now the factor ordering is preserved.

cc @andrewheiss @dicook 