### PR TITLE
Small ggally_crostable() and ggtable() fix

### DIFF
--- a/R/ggtable.R
+++ b/R/ggtable.R
@@ -21,7 +21,7 @@
 #' ggtable(tips, "smoker", c("day", "time", "sex"), cells = "row.prop")
 #'
 #' # filling cells with standardized residuals
-#' ggtable(tips, "smoker", c("day", "time", "sex"), fill = "stdres")
+#' ggtable(tips, "smoker", c("day", "time", "sex"), fill = "stdres", legend = 1)
 #'
 #' # if continuous variables are provided, just displaying some summary statistics
 #' ggtable(tips, c("smoker", "total_bill"), c("day", "time", "sex", "tip"))
@@ -67,8 +67,6 @@ ggtable <- function(
     ggduo_args$xProportions <- "auto"
   if (!"yProportions" %in% names(ggduo_args))
     ggduo_args$yProportions <- "auto"
-  if (!"legend" %in% names(ggduo_args) & fill == "stdres")
-    ggduo_args$legend <- 1
 
   p <- do.call(ggduo, ggduo_args)
   p

--- a/R/stat_cross.R
+++ b/R/stat_cross.R
@@ -400,7 +400,7 @@ ggally_crosstable <- function(
     theme(axis.ticks = element_blank())
 
   if (fill == "stdres")
-    p <- p + scale_fill_steps2(breaks = c(-3, -2, 2, 3), show.limits = TRUE)
+    p <- p + scale_fill_steps2(breaks = c(-Inf, -3, -2, 2, 3, Inf))
 
   p
 }


### PR DESCRIPTION
Better to not show by default limits because in a plot matrix limits will change in the different subplots.

Subplot to select the legend should indicated manually because otherwise there could be errors if the first sub-plot do not have a legend