### PR TITLE
bug fix in ggcoef_model when tidy() does not return a p.value

### DIFF
--- a/R/ggcoef_model.R
+++ b/R/ggcoef_model.R
@@ -495,6 +495,11 @@ ggcoef_data <- function (
     keep_model = FALSE
   )
 
+  if (!"p.value" %in% names(data)) {
+    data$p.value <- NA_real_
+    significance <- NULL
+  }
+
   if(!is.null(significance)) {
     if (is.null(significance_labels))
       significance_labels <- paste(c("p \u2264", "p >"), significance)

--- a/tests/testthat/test-ggcoef_model.R
+++ b/tests/testthat/test-ggcoef_model.R
@@ -130,6 +130,9 @@ test_that("example of ggcoef_model", {
 })
 
 test_that("ggcoef_model works with tieders not returning p-values", {
+  skip_if_not_installed("broom.helpers")
+  skip_if_not_installed("scagnostics")
+
   mod <- lm(Sepal.Width ~ Species, iris)
   my_tidier <- function(x, ...) {
     x %>%

--- a/tests/testthat/test-ggcoef_model.R
+++ b/tests/testthat/test-ggcoef_model.R
@@ -92,12 +92,15 @@ test_that("example of ggcoef_model", {
 
   # or with different type of contrasts
   # for sum contrasts, the value of the reference term is computed
-  mod2 <- lm(
-    tip ~ day + time + sex,
-    data = tips,
-    contrasts = list(time = contr.sum, day = contr.treatment(4, base = 3))
-  )
-  expect_print(ggcoef_model(mod2))
+  if (requireNamespace("emmeans")) {
+    mod2 <- lm(
+      tip ~ day + time + sex,
+      data = tips,
+      contrasts = list(time = contr.sum, day = contr.treatment(4, base = 3))
+    )
+    expect_print(ggcoef_model(mod2))
+
+  }
 
   # Use ggcoef_compare() for comparing several models on the same plot
   mod1 <- lm(Fertility ~ ., data = swiss)

--- a/tests/testthat/test-ggcoef_model.R
+++ b/tests/testthat/test-ggcoef_model.R
@@ -92,7 +92,8 @@ test_that("example of ggcoef_model", {
 
   # or with different type of contrasts
   # for sum contrasts, the value of the reference term is computed
-  if (requireNamespace("emmeans")) {
+  emmeans_is_installed <- (system.file(package = "emmeans") != "")
+  if (emmeans_is_installed) {
     mod2 <- lm(
       tip ~ day + time + sex,
       data = tips,

--- a/tests/testthat/test-ggcoef_model.R
+++ b/tests/testthat/test-ggcoef_model.R
@@ -124,3 +124,17 @@ test_that("example of ggcoef_model", {
 
 
 })
+
+test_that("ggcoef_model works with tieders not returning p-values", {
+  mod <- lm(Sepal.Width ~ Species, iris)
+  my_tidier <- function(x, ...) {
+    x %>%
+      broom::tidy(...) %>%
+      dplyr::select(-.data$p.value)
+  }
+  expect_error(
+    mod %>% ggcoef_model(tidy_fun = my_tidier),
+    NA
+  )
+
+})


### PR DESCRIPTION
Some tieders do not return p-values. Avoid an error in such case.