### PR TITLE
No more warning when using `colour_guide = FALSE` or `shape_guide = FALSE`   with `ggcoef_plot()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # GGally (development version)
 
+### Bug fixes
+
+* No more warning when using `colour_guide = FALSE` or `shape_guide = FALSE`
+  with `ggcoef_plot()` (@larmarange, #413)
+
+
 # GGally 2.1.1
 
 ### Bug fixes

--- a/R/ggcoef_model.R
+++ b/R/ggcoef_model.R
@@ -713,16 +713,22 @@ ggcoef_plot <- function (
     )
 
   if(!is.null(colour) && colour %in% names(data)) {
-    if (colour_guide)
+    if (colour_guide) {
       colour_guide <- guide_legend()
+    } else {
+      colour_guide <- "none"
+    }
     p <- p +
       scale_colour_discrete(guide = colour_guide, labels = colour_labels) +
       labs(colour = colour_lab)
   }
 
   if(!is.null(shape) && shape %in% names(data)) {
-    if (shape_guide)
+    if (shape_guide) {
       shape_guide <- guide_legend()
+    } else {
+      shape_guide <- "none"
+    }
     p <- p +
       scale_shape_manual(
         values = shape_values,

--- a/tests/testthat/test-ggcoef_model.R
+++ b/tests/testthat/test-ggcoef_model.R
@@ -11,6 +11,13 @@ test_that("example of ggcoef_model", {
   mod_simple <- lm(tip ~ day + time + total_bill, data = tips)
   expect_print(ggcoef_model(mod_simple))
 
+  expect_warning(
+    print(
+      ggcoef_model(mod_simple, shape_guide = FALSE, colour_guide = FALSE)
+    ),
+    NA
+  )
+
   # custom variable labels
   # you can use to define variable labels before computing model
   if (require(labelled)) {


### PR DESCRIPTION
fix #413 