### PR TITLE
Fix no_reference_row option in ggcoeff_compare()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,11 +1,10 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - master
-      - rc-*
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -19,90 +18,29 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # - { os: macOS-latest,   r: 'devel',   force_suggests: "0" }
-          # - { os: window-latest,   r: 'devel',   force_suggests: "1" }
-
-          - { os: macOS-latest,   r: 'release', force_suggests: "1" }
-          - { os: windows-latest, r: 'release', force_suggests: "1" }
-          - { os: ubuntu-16.04,   r: 'release', force_suggests: "1",  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest" }
-          - { os: ubuntu-20.04,   r: 'release', force_suggests: "1",  rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
-
-          - { os: macOS-latest,   r: 'oldrel',  force_suggests: "1" }
-          - { os: windows-latest, r: 'oldrel',  force_suggests: "1" }
-          - { os: ubuntu-16.04,   r: 'oldrel',  force_suggests: "1" , rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest" }
-          - { os: ubuntu-20.04,   r: 'oldrel',  force_suggests: "1" , rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      _R_CHECK_FORCE_SUGGESTS_: ${{ matrix.config.force_suggests }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
-        id: install-r
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Install pak and query dependencies
-        shell: Rscript {0}
-        run: |
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-          saveRDS(pak::pkg_deps_tree("local::.", dependencies = TRUE), ".github/r-depends.rds")
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-
+          extra-packages: rcmdcheck
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        shell: Rscript {0}
-        run: |
-          pak::local_system_requirements(execute = TRUE)
-          pak::pkg_system_requirements("rcmdcheck", execute = TRUE)
-          pak::pkg_system_requirements("sessioninfo", execute = TRUE)
-
-      - name: Install dependencies
-        shell: Rscript {0}
-        run: |
-          pak::local_install_dev_deps(upgrade = TRUE)
-          pak::pkg_install(c("rcmdcheck", "sessioninfo"))
-
-      - name: Session info
-        shell: Rscript {0}
-        run: |
-          options(width = 100)
-          pkgs <- installed.packages()[, "Package"]
-          sessioninfo::session_info(pkgs, include_base = TRUE)
-
-      - name: Check with printing
-        env:
-          _R_CHECK_CRAN_INCOMING_: false
-          CAN_PRINT: "TRUE"
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Check as CRAN
-        env:
-          _R_CHECK_CRAN_INCOMING_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@master
-        with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+      - uses: r-lib/actions/check-r-package@v1

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,87 +1,35 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - master
-      - "**pkgdown**"
-  pull_request:
-    branches:
-      - master
-      - rc-**
-
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ${{ matrix.config.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - { os: ubuntu-16.04,   r: 'release', force_suggests: "1",  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest" }
-
+    runs-on: ubuntu-latest
     env:
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
-        id: install-r
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
         with:
-          r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Install pak and query dependencies
-        shell: Rscript {0}
-        run: |
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-          saveRDS(pak::pkg_deps_tree("local::.", dependencies = TRUE), ".github/r-depends.rds")
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-pkgdown-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: |
-            ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-pkgdown-
-            ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-
+          extra-packages: pkgdown
+          needs: website
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        shell: Rscript {0}
+      - name: Deploy package
         run: |
-          pak::local_system_requirements(execute = TRUE)
-          pak::pkg_system_requirements("pkgdown", execute = TRUE)
-
-      - name: Install dependencies
-        shell: Rscript {0}
-        run: |
-          pak::local_install_dev_deps(upgrade = TRUE)
-          pak::pkg_install("pkgdown")
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Build Site (PR)
-        if: github.event_name != 'push'
-        env:
-          CAN_PRINT: "TRUE"
-        run: |
-          pkgdown::build_site()
-          stopifnot(length(warnings()) == 0)
-        shell: Rscript {0}
-
-      - name: Git Config
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-
-      - name: Build and Deploy Site
-        if: github.event_name == 'push'
-        env:
-          CAN_PRINT: "TRUE"
-        run: pkgdown::deploy_to_branch(new_process = FALSE)
-        shell: Rscript {0}
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,66 +1,30 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - master
-      - rc-*
+    branches: [main, master]
 
 name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: ${{ matrix.config.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - { os: ubuntu-16.04,   r: 'release', force_suggests: "1",  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest" }
+    runs-on: ubuntu-latest
     env:
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
-        id: install-r
+      - uses: r-lib/actions/setup-r@v1
         with:
-          r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Install pak and query dependencies
-        shell: Rscript {0}
-        run: |
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-          saveRDS(pak::pkg_deps_tree("local::.", dependencies = TRUE), ".github/r-depends.rds")
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-testing-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: |
-            ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-testing-
-            ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-
-
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        shell: Rscript {0}
-        run: |
-          pak::local_system_requirements(execute = TRUE)
-          pak::pkg_system_requirements("covr", execute = TRUE)
-
-      - name: Install dependencies
-        shell: Rscript {0}
-        run: |
-          pak::local_install_dev_deps(upgrade = TRUE)
-          pak::pkg_install("covr")
+          extra-packages: covr
 
       - name: Test coverage
-        env:
-          CAN_PRINT: "TRUE"
         run: covr::codecov()
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     utils
 Suggests:
     broom (>= 0.7.0),
-    broom.helpers (>= 1.1.0),
+    broom.helpers (>= 1.3.0),
     chemometrics,
     geosphere (>= 1.5-1),
     ggforce,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,7 @@ Suggests:
     spelling,
     emmeans
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 SystemRequirements: openssl
 Encoding: UTF-8
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Reverse ordering of y-axis in `ggally_count()` (#420)
 * Facets ordering in `ggcoef_compare()` (#426)
+* Bug fix for `ggcoef_compare()` when using tidy selectors for 
+  `no_reference_row` (#430)
 
 
 # GGally 2.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,9 @@
 * Facets ordering in `ggcoef_compare()` (#426)
 * Bug fix for `ggcoef_compare()` when using tidy selectors for 
   `no_reference_row` (#430)
-
+* Fix in `ggcoef_compare()` regarding `no_reference_row` option (#430)
+* New default tidier for `ggcoef_model()`, now using
+  `broom.helpers::tidy_with_broom_or_parameters()` (#432)
 
 # GGally 2.1.2
 

--- a/R/ggcoef_model.R
+++ b/R/ggcoef_model.R
@@ -144,7 +144,7 @@
 #' }
 ggcoef_model <- function (
   model,
-  tidy_fun = broom::tidy,
+  tidy_fun = broom.helpers::tidy_with_broom_or_parameters,
   conf.int = TRUE,
   conf.level = .95,
   exponentiate = FALSE,
@@ -252,7 +252,7 @@ ggcoef_model <- function (
 ggcoef_compare <- function (
   models,
   type = c("dodged", "faceted"),
-  tidy_fun = broom::tidy,
+  tidy_fun = broom.helpers::tidy_with_broom_or_parameters,
   conf.int = TRUE,
   conf.level = .95,
   exponentiate = FALSE,
@@ -373,7 +373,7 @@ ggcoef_multinom <- function (
   model,
   type = c("dodged", "faceted"),
   y.level_label = NULL,
-  tidy_fun = broom::tidy,
+  tidy_fun = broom.helpers::tidy_with_broom_or_parameters,
   conf.int = TRUE,
   conf.level = .95,
   exponentiate = FALSE,
@@ -457,7 +457,7 @@ ggcoef_multinom <- function (
 # not exporting ggcoef_data
 ggcoef_data <- function (
   model,
-  tidy_fun = broom::tidy,
+  tidy_fun = broom.helpers::tidy_with_broom_or_parameters,
   conf.int = TRUE,
   conf.level = .95,
   exponentiate = FALSE,

--- a/R/ggcoef_model.R
+++ b/R/ggcoef_model.R
@@ -174,9 +174,9 @@ ggcoef_model <- function (
     interaction_sep = interaction_sep,
     categorical_terms_pattern = categorical_terms_pattern,
     add_reference_rows = add_reference_rows,
-    no_reference_row  = no_reference_row,
+    no_reference_row  = {{ no_reference_row }},
     intercept = intercept,
-    include = include,
+    include = {{ include }},
     significance = significance,
     significance_labels = significance_labels
   )
@@ -281,7 +281,7 @@ ggcoef_compare <- function (
     interaction_sep = interaction_sep,
     categorical_terms_pattern = categorical_terms_pattern,
     add_reference_rows = add_reference_rows,
-    no_reference_row  = no_reference_row ,
+    no_reference_row = {{ no_reference_row }},
     intercept = intercept,
     significance = significance,
     significance_labels = significance_labels
@@ -295,7 +295,7 @@ ggcoef_compare <- function (
   # include should be applied after lapply
   data <- data %>%
     broom.helpers::tidy_select_variables(
-      include = include,
+      include = {{ include }},
       model = models[[1]] # we just need to pass a model to allow the function to work
     ) %>%
     broom.helpers::tidy_detach_model()
@@ -403,9 +403,9 @@ ggcoef_multinom <- function (
     interaction_sep = interaction_sep,
     categorical_terms_pattern = categorical_terms_pattern,
     add_reference_rows = add_reference_rows,
-    no_reference_row  = no_reference_row,
+    no_reference_row  = {{ no_reference_row }},
     intercept = intercept,
-    include = include,
+    include = {{ include }},
     significance = significance,
     significance_labels = significance_labels
   )
@@ -489,11 +489,11 @@ ggcoef_data <- function (
     interaction_sep = interaction_sep,
     categorical_terms_pattern = categorical_terms_pattern,
     add_reference_rows = add_reference_rows,
-    no_reference_row = no_reference_row,
+    no_reference_row = {{ no_reference_row }},
     add_estimate_to_reference_rows = TRUE,
     add_header_rows = FALSE,
     intercept = intercept,
-    include = include,
+    include = {{ include }},
     keep_model = FALSE
   )
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![](http://cranlogs.r-pkg.org/badges/GGally)](https://cran.r-project.org/package=GGally)
 [![DOI](https://zenodo.org/badge/22529/ggobi/ggally.svg)](https://zenodo.org/badge/latestdoi/22529/ggobi/ggally)
 [![RStudio community](https://img.shields.io/badge/community-GGally-blue?style=social&logo=rstudio&logoColor=75AADB)](https://community.rstudio.com/tags/c/general/17/ggally)
+[![R-CMD-check](https://github.com/ggobi/ggally/workflows/R-CMD-check/badge.svg)](https://github.com/ggobi/ggally/actions)
 <!-- badges: end -->
 
 

--- a/man/GGally-package.Rd
+++ b/man/GGally-package.Rd
@@ -6,12 +6,7 @@
 \alias{GGally-package}
 \title{GGally: Extension to 'ggplot2'}
 \description{
-The R package 'ggplot2' is a plotting system based on the grammar of graphics.
-    'GGally' extends 'ggplot2' by adding several functions
-    to reduce the complexity of combining geometric objects with transformed data.
-    Some of these functions include a pairwise plot matrix, a two group pairwise plot
-    matrix, a parallel coordinates plot, a survival plot, and several functions to
-    plot networks.
+The R package 'ggplot2' is a plotting system based on the grammar of graphics. 'GGally' extends 'ggplot2' by adding several functions to reduce the complexity of combining geometric objects with transformed data. Some of these functions include a pairwise plot matrix, a two group pairwise plot matrix, a parallel coordinates plot, a survival plot, and several functions to plot networks.
 }
 \seealso{
 Useful links:

--- a/man/ggcoef_model.Rd
+++ b/man/ggcoef_model.Rd
@@ -9,7 +9,7 @@
 \usage{
 ggcoef_model(
   model,
-  tidy_fun = broom::tidy,
+  tidy_fun = broom.helpers::tidy_with_broom_or_parameters,
   conf.int = TRUE,
   conf.level = 0.95,
   exponentiate = FALSE,
@@ -32,7 +32,7 @@ ggcoef_model(
 ggcoef_compare(
   models,
   type = c("dodged", "faceted"),
-  tidy_fun = broom::tidy,
+  tidy_fun = broom.helpers::tidy_with_broom_or_parameters,
   conf.int = TRUE,
   conf.level = 0.95,
   exponentiate = FALSE,
@@ -54,7 +54,7 @@ ggcoef_multinom(
   model,
   type = c("dodged", "faceted"),
   y.level_label = NULL,
-  tidy_fun = broom::tidy,
+  tidy_fun = broom.helpers::tidy_with_broom_or_parameters,
   conf.int = TRUE,
   conf.level = 0.95,
   exponentiate = FALSE,


### PR DESCRIPTION
Fix #430 
Fix #432 

``` r
library(GGally)
#> Le chargement a nécessité le package : ggplot2
#> Registered S3 method overwritten by 'GGally':
#>   method from   
#>   +.gg   ggplot2

m1 <- glm(smoker ~ day + time + total_bill, data = reshape::tips, family = "binomial")
m2 <- glm(smoker ~ day + time + sex, data = reshape::tips, family = "binomial")

ggcoef_compare(
  list("Model 1"= m1, "Model 2" = m2), 
  type = "faceted", exponentiate = TRUE,
  no_reference_row = broom.helpers::all_dichotomous()
) 
```

![](https://i.imgur.com/fFBl99Y.png)

``` r
ggcoef_compare(
  list("Model 2"= m2, "Model 1" = m1), 
  type = "faceted", exponentiate = TRUE,
  no_reference_row = broom.helpers::all_dichotomous()
) 
```

![](https://i.imgur.com/wWEVXVL.png)

<sup>Created on 2021-11-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
