### PR TITLE
Remove use of `packageVersion()`

### DIFF
--- a/R/gg-plots.R
+++ b/R/gg-plots.R
@@ -1128,14 +1128,7 @@ get_x_axis_labels <- function(p, xRange) {
     }
     NULL
   }
-  name <-
-    if (packageVersion("ggplot2") >= 3.3) {
-      "title"
-    } else {
-      "axis.text.x"
-    }
-
-  xAxisGrob <- get_raw_grob_by_name(axisTable, name)
+  xAxisGrob <- get_raw_grob_by_name(axisTable, "title")
 
   axisBreaks <- as.numeric(xAxisGrob$label)
 


### PR DESCRIPTION
Since ggplot2 min version is 3.3.4, then it'll always be title. So the code could be simplified.

Original request from CRAN to change code to quoted `"3.3"`. But if the line isn't necessary, then we can skip it.