### PR TITLE
Compatibility with ggplot2 3.5.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # GGally (development version)
 
+* Fix compatibility with ggplot2 3.5.0 (#481)
+
 # GGally 2.2.0
 
 ### Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # GGally (development version)
 
-* Fix compatibility with ggplot2 3.5.0 (#481)
+* Fix compatibility with ggplot2 3.5.0 (@teunbrand, #481)
 
 # GGally 2.2.0
 

--- a/R/ggmatrix_legend.R
+++ b/R/ggmatrix_legend.R
@@ -34,8 +34,11 @@ grab_legend <- function(p) {
 get_legend_from_gtable <- function(pTable) {
   ret <- ggplot2::zeroGrob()
   if (inherits(pTable, "gtable")) {
-    if ("guide-box" %in% pTable$layout$name) {
+    if (any(grepl("guide-box", pTable$layout$name))) {
       ret <- gtable_filter(pTable, "guide-box")
+      keep <- !vapply(ret$grobs, inherits, what = "zeroGrob", logical(1))
+      keep <- paste0(ret$layout$name[keep], collapse = "|")
+      ret  <- gtable_filter(ret, keep)
     }
   }
   class(ret) <- c("legend_guide_box", class(ret))


### PR DESCRIPTION
TL;DR: This PR aims to fix #481.

We have been preparing a new release of ggplot2, and during a reverse dependency check, it became apparent that the prospective ggplot 3.5.0 would break GGally.
Given GGally's important role in the R ecosystem, we felt it was prudent to help out to transition to the new version.
The culprit is that ggplot2 changed the way legends are placed in the gtable, see https://github.com/tidyverse/ggplot2/pull/5488.
This PR handles the new legend structure, and should work with both the current and the development version of ggplot2.
To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled at the end of January / early Februari. The progress can be tracked in https://github.com/tidyverse/ggplot2/issues/5588.
We are hoping that this PR might help GGally be ready around that time to soften the impact on downstream packages.