### PR TITLE
Use rbind() where rbind.fill() is not needed

### DIFF
--- a/R/ggaly_trends.R
+++ b/R/ggaly_trends.R
@@ -87,7 +87,7 @@ ggally_trends <- function(
         tmp <- data
         tmp[[".ggally_y"]] <- as.integer(y == l)
         tmp$y <- l
-        d <- plyr::rbind.fill(d, tmp)
+        d <- rbind(d, tmp)
       }
       mapping$linetype <- aes(y = !!as.name("y"))$y
       mapping$y <- aes(y = !!as.name(".ggally_y"))$y


### PR DESCRIPTION
Continuing the series refactoring away {plyr} imports (#520, #521)

Here, AFAICT, `rbind.fill()` is not needed -- `rbind()` will suffice. We repeatedly concatenate `data` with two extra columns (`.ggally_y` [integer] and `y` [`typeof(l)`]). The `.fill()` extension is used for the case the schema of the inputs may not match, not so here.