### PR TITLE
fix: Move `ggplot2::build_ggplot()` to `ggplot2::ggplot_build()`

### DIFF
--- a/tests/testthat/test-zzz_ggpairs.R
+++ b/tests/testthat/test-zzz_ggpairs.R
@@ -600,8 +600,8 @@ test_that("user functions", {
     )
 
     if (packageVersion("ggplot2") > "3.5.2") {
-      x_built <- ggplot2::build_ggplot(x)
-      y_built <- ggplot2::build_ggplot(y)
+      x_built <- ggplot2::ggplot_build(x)
+      y_built <- ggplot2::ggplot_build(y)
       expect_equal(
         x_built@plot@labels[c("x", "y")],
         list(x = "total_bill", y = "tip")


### PR DESCRIPTION
Fixes tidyverse/ggplot2#6568