### PR TITLE
test: use snapshot errors

### DIFF
--- a/tests/testthat/_snaps/crosstalk.md
+++ b/tests/testthat/_snaps/crosstalk.md
@@ -1,0 +1,47 @@
+# crosstalk works with ggduo and ggpairs
+
+    Code
+      ggpairs(sd, 3:5)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columns" values are less than or equal to 4.
+      * columns = c(3, 4, 5)
+
+---
+
+    Code
+      ggpairs(sd, c("Petal.Length", "Petal.Width", crosstalk_key()))
+    Condition
+      Error in `fix_column_values()`:
+      ! Columns in `columns` not found in data: `'.crossTalkKey'`.
+      i Choices: `Sepal.Length`, `Sepal.Width`, `Petal.Length`, and `Petal.Width`
+
+---
+
+    Code
+      ggduo(sd, c(1:2, 5), 3:5)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columnsX" values are less than or equal to 4.
+      * columnsX = c(1, 2, 5)
+
+---
+
+    Code
+      ggduo(sd, c("Sepal.Length", "Sepal.Width", crosstalk_key()), c("Petal.Length",
+        "Petal.Width"))
+    Condition
+      Error in `fix_column_values()`:
+      ! Columns in `columnsX` not found in data: `'.crossTalkKey'`.
+      i Choices: `Sepal.Length`, `Sepal.Width`, `Petal.Length`, and `Petal.Width`
+
+---
+
+    Code
+      ggduo(sd, c("Sepal.Length", "Sepal.Width"), c("Petal.Length", "Petal.Width",
+        crosstalk_key()))
+    Condition
+      Error in `fix_column_values()`:
+      ! Columns in `columnsY` not found in data: `'.crossTalkKey'`.
+      i Choices: `Sepal.Length`, `Sepal.Width`, `Petal.Length`, and `Petal.Width`
+

--- a/tests/testthat/_snaps/gg-plots.md
+++ b/tests/testthat/_snaps/gg-plots.md
@@ -1,0 +1,16 @@
+# cor
+
+    Code
+      ggally_cor(ti, ggplot2::aes(x = total_bill, y = tip, color = size))
+    Condition
+      Error in `ggally_statistic()`:
+      ! `mapping` color column must be categorical, not numeric
+
+# diagAxis
+
+    Code
+      ggally_diagAxis(iris, mapping = ggplot2::aes(y = Sepal.Length))
+    Condition
+      Error in `ggally_diagAxis()`:
+      ! mapping$x is null. There must be a column value in this location.
+

--- a/tests/testthat/_snaps/ggcorr.md
+++ b/tests/testthat/_snaps/ggcorr.md
@@ -1,0 +1,16 @@
+# further options
+
+    Code
+      ggcorr(flea[, -1], layout.exp = "a")
+    Condition
+      Error in `ggcorr()`:
+      ! incorrect `layout.exp` value
+
+# other geoms
+
+    Code
+      ggcorr(flea[, -1], geom = "hexbin")
+    Condition
+      Error in `ggcorr()`:
+      ! incorrect geom value
+

--- a/tests/testthat/_snaps/ggmatrix.md
+++ b/tests/testthat/_snaps/ggmatrix.md
@@ -1,0 +1,81 @@
+# stops
+
+    Code
+      ggmatrix(plots = matrix(), nrow = 2, ncol = 3)
+    Condition
+      Error in `ggmatrix()`:
+      ! `plots` must be a `list()`
+
+---
+
+    Code
+      ggmatrix(plots = list(), nrow = "2", ncol = 3)
+    Condition
+      Error in `check_nrow_ncol()`:
+      ! `nrow` must be a numeric value
+
+---
+
+    Code
+      ggmatrix(plots = list(), nrow = 2, ncol = "3")
+    Condition
+      Error in `check_nrow_ncol()`:
+      ! `ncol` must be a numeric value
+
+---
+
+    Code
+      ggmatrix(plots = list(), nrow = c(2, 3), ncol = 3)
+    Condition
+      Error in `check_nrow_ncol()`:
+      ! `nrow` must be a single numeric value
+
+---
+
+    Code
+      ggmatrix(plots = list(), nrow = 2, ncol = c(2, 3))
+    Condition
+      Error in `check_nrow_ncol()`:
+      ! `ncol` must be a single numeric value
+
+# expression labels
+
+    Code
+      print(ggpairs(tips, 1:2, columnLabels = expression(alpha, beta)))
+    Condition
+      Error in `get_labels()`:
+      ! `xAxisLabels` can only be a character vector or `NULL`.
+      i Character values can be parsed using the `labeller` parameter.
+
+# blank
+
+    Code
+      pm[2, 2] <- "not blank"
+    Condition
+      Error in `putPlot()`:
+      ! character values (besides `'blank'`) are not allowed to be stored as plot values.
+
+# ggmatrix proportions
+
+    Code
+      ggmatrix_proportions("not auto", tips, 1:ncol(tips))
+    Condition
+      Error in `ggmatrix_proportions()`:
+      ! `proportions` need to be non-NA numeric values or `'auto'`. proportions: "not auto"
+
+---
+
+    Code
+      ggmatrix_proportions(NA, tips, 1:ncol(tips))
+    Condition
+      Error in `ggmatrix_proportions()`:
+      ! `proportions` need to be non-NA numeric values or `'auto'`. proportions: NA
+
+---
+
+    Code
+      ggmatrix_proportions(c(1, NA, 1, 1, 1, 1, 1), tips, 1:ncol(tips))
+    Condition
+      Error in `ggmatrix_proportions()`:
+      ! `proportions` need to be non-NA numeric values or `'auto'`. proportions: c(1, NA, 1, 1, 1, 1, 1)
+

--- a/tests/testthat/_snaps/ggmatrix_add.md
+++ b/tests/testthat/_snaps/ggmatrix_add.md
@@ -1,3 +1,12 @@
+# add
+
+    Code
+      pm + 3
+    Condition
+      Error in `+.ggmatrix`:
+      ! `ggmatrix()` does not know how to add objects that do not have class <theme>, <labels> or <ggproto>.
+      i Received object with class: <numeric>
+
 # v1_ggmatrix_theme
 
     Code

--- a/tests/testthat/_snaps/ggmatrix_getput.md
+++ b/tests/testthat/_snaps/ggmatrix_getput.md
@@ -1,0 +1,73 @@
+# stops
+
+    Code
+      pm["total_bill", 1]
+    Condition
+      Error in `check_i_j()`:
+      ! `i` may only be a single numeric value
+
+---
+
+    Code
+      pm[1, "total_bill"]
+    Condition
+      Error in `check_i_j()`:
+      ! `j` may only be a single numeric value
+
+---
+
+    Code
+      pm["total_bill", 1] <- p
+    Condition
+      Error in `check_i_j()`:
+      ! `i` may only be a single numeric value
+
+---
+
+    Code
+      pm[1, "total_bill"] <- p
+    Condition
+      Error in `check_i_j()`:
+      ! `j` may only be a single numeric value
+
+---
+
+    Code
+      pm[0, 1]
+    Condition
+      Error in `check_i_j()`:
+      ! `i` may only be in the range from 1:4
+
+---
+
+    Code
+      pm[1, 0]
+    Condition
+      Error in `check_i_j()`:
+      ! `j` may only be in the range from 1:3
+
+---
+
+    Code
+      pm[5, 1]
+    Condition
+      Error in `check_i_j()`:
+      ! `i` may only be in the range from 1:4
+
+---
+
+    Code
+      pm[1, 4]
+    Condition
+      Error in `check_i_j()`:
+      ! `j` may only be in the range from 1:3
+
+# get
+
+    Code
+      a[2, 1]
+    Condition
+      Error in `getPlot()`:
+      ! unknown plot object type.
+      i Position: i = 2, j = 1 str(plotObj): int [1:4] 1 2 3 4
+

--- a/tests/testthat/_snaps/ggmatrix_location.md
+++ b/tests/testthat/_snaps/ggmatrix_location.md
@@ -1,0 +1,132 @@
+# rows work
+
+    Code
+      ggmatrix_location(pm, rows = TRUE)
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `rows` must be numeric
+
+---
+
+    Code
+      ggmatrix_location(pm, rows = "1")
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `rows` must be numeric
+
+# cols work
+
+    Code
+      ggmatrix_location(pm, cols = TRUE)
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `cols` must be numeric
+
+---
+
+    Code
+      ggmatrix_location(pm, cols = "1")
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `cols` must be numeric
+
+# location character
+
+    Code
+      ggmatrix_location(pm, location = "unknown")
+    Condition
+      Error in `match.arg()`:
+      ! 'arg' should be one of "all", "upper", "lower", "diag", "none"
+
+# location matrix
+
+    Code
+      ggmatrix_location(pm, location = mat[, 1:6])
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `location` provided does not have the same size of columns
+
+---
+
+    Code
+      ggmatrix_location(pm, location = mat[1:6, ])
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `location` provided does not have the same size of rows
+
+---
+
+    Code
+      ggmatrix_location(pm, location = cbind(mat, 1))
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `location` provided does not have the same size of columns
+
+---
+
+    Code
+      ggmatrix_location(pm, location = rbind(mat, 1))
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `location` provided does not have the same size of rows
+
+---
+
+    Code
+      ggmatrix_location(pm, location = expand.grid(row = 1:7, col = 2:8))
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `col` must be non-NA / positive numeric values `<= pm$ncol`
+      * `pm$ncol`: 7
+      * `col`: 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, ..., 8, and 8
+
+---
+
+    Code
+      ggmatrix_location(pm, location = expand.grid(row = 2:8, col = 1:7))
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `row` must be non-NA / positive numeric values `<= pm$nrow`
+      * `pm$nrow`: 7
+      * row: 2, 3, 4, 5, 6, 7, 8, 2, 3, 4, 5, 6, 7, 8, 2, 3, 4, 5, ..., 7, and 8
+
+---
+
+    Code
+      ggmatrix_location(pm, location = expand.grid(row = 1:7, col = 0:6))
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `col` must be non-NA / positive numeric values `<= pm$ncol`
+      * `pm$ncol`: 7
+      * `col`: 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, ..., 6, and 6
+
+---
+
+    Code
+      ggmatrix_location(pm, location = expand.grid(row = 0:6, col = 1:7))
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `row` must be non-NA / positive numeric values `<= pm$nrow`
+      * `pm$nrow`: 7
+      * row: 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, ..., 5, and 6
+
+---
+
+    Code
+      ggmatrix_location(pm, location = expand.grid(row = 1:7, col = c(1:6, NA)))
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `col` must be non-NA / positive numeric values `<= pm$ncol`
+      * `pm$ncol`: 7
+      * `col`: 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, ..., NA, and NA
+
+---
+
+    Code
+      ggmatrix_location(pm, location = expand.grid(row = c(1:6, NA), col = 1:7))
+    Condition
+      Error in `ggmatrix_location()`:
+      ! `row` must be non-NA / positive numeric values `<= pm$nrow`
+      * `pm$nrow`: 7
+      * row: 1, 2, 3, 4, 5, 6, NA, 1, 2, 3, 4, 5, 6, NA, 1, 2, 3, 4, ..., 6, and NA
+

--- a/tests/testthat/_snaps/ggnet.md
+++ b/tests/testthat/_snaps/ggnet.md
@@ -1,0 +1,202 @@
+# examples
+
+    Code
+      ggnet(n, group = NA)
+    Condition
+      Error in `set_node()`:
+      ! incorrect node.group value
+
+---
+
+    Code
+      ggnet(n, group = 1:3)
+    Condition
+      Error in `set_node()`:
+      ! incorrect node.group length
+
+---
+
+    Code
+      ggnet(n, label = TRUE, label.size = -10:-1)
+    Condition
+      Error in `set_node()`:
+      ! incorrect label.size value
+
+---
+
+    Code
+      ggnet(n, size = "phono")
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `size` value
+
+---
+
+    Code
+      ggnet(n, segment.label = NA)
+    Condition
+      Error in `set_edge()`:
+      ! incorrect segment.label value
+
+---
+
+    Code
+      ggnet(n, segment.label = 1:3)
+    Condition
+      Error in `set_edge()`:
+      ! incorrect segment.label length
+
+---
+
+    Code
+      ggnet(n, segment.label = -11:-1)
+    Condition
+      Error in `set_edge()`:
+      ! incorrect segment.label value
+
+---
+
+    Code
+      ggnet(n, mode = c("xx", "yy"))
+    Condition
+      Error in `set_attr()`:
+      ! vertex attribute xx was not found
+
+---
+
+    Code
+      ggnet(n, mode = c("abc", "abc"))
+    Condition
+      Error in `set_attr()`:
+      ! vertex attribute abc is not numeric
+
+---
+
+    Code
+      ggnet(n, mode = matrix(1, ncol = 2, nrow = 9))
+    Condition
+      Error in `set_attr()`:
+      ! incorrect coordinates length
+
+---
+
+    Code
+      ggnet(n, arrow.size = -1)
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `arrow.size` value
+
+---
+
+    Code
+      ggnet(n, arrow.size = 12, arrow.gap = -1)
+    Condition
+      Warning:
+      network is undirected; `arrow.size` ignored
+      Error in `ggnet()`:
+      ! incorrect `arrow.gap` value
+
+---
+
+    Code
+      ggnet(n, weight = "degree", weight.min = -1)
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `weight.min` value
+
+---
+
+    Code
+      ggnet(n, weight = "degree", weight.max = -1)
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `weight.max` value
+
+---
+
+    Code
+      ggnet(n, weight = "abc")
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `weight.method` value
+
+---
+
+    Code
+      ggnet(n, weight.cut = NA)
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `weight.cut` value
+
+---
+
+    Code
+      ggnet(n, weight.cut = "a")
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `weight.cut` value
+
+---
+
+    Code
+      ggnet(n, label = letters[1:10], label.size = "abc")
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `label.size` value
+
+---
+
+    Code
+      ggnet(n, mode = "xyz")
+    Condition
+      Error in `ggnet()`:
+      ! unsupported placement method: "gplot.layout.xyz"
+
+---
+
+    Code
+      ggnet(n, mode = letters[1:3])
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `mode` value
+
+---
+
+    Code
+      ggnet(n, label = TRUE, label.trim = "xyz")
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `label.trim` value
+
+---
+
+    Code
+      ggnet(n, layout.exp = "xyz")
+    Condition
+      Error in `ggnet()`:
+      ! incorrect `layout.exp` value
+
+---
+
+    Code
+      ggnet(1:2)
+    Condition
+      Error in `ggnet()`:
+      ! could not coerce `net` to a network object
+
+---
+
+    Code
+      ggnet(network(data.frame(1:2, 3:4), hyper = TRUE))
+    Condition
+      Error:
+      ! If `hyper` is `TRUE`, the first two columns of `x` should be list columns.
+
+---
+
+    Code
+      ggnet(network(data.frame(1:2, 3:4), multiple = TRUE))
+    Condition
+      Error in `ggnet()`:
+      ! ggnet cannot plot multiplex graphs
+

--- a/tests/testthat/_snaps/ggnet2.md
+++ b/tests/testthat/_snaps/ggnet2.md
@@ -1,0 +1,309 @@
+# examples
+
+    Code
+      ggnet2(n, color = NA)
+    Condition
+      Error in `set_node()`:
+      ! incorrect node.color value
+
+---
+
+    Code
+      ggnet2(n, color = -1)
+    Condition
+      Error in `set_node()`:
+      ! incorrect node.color value
+
+---
+
+    Code
+      ggnet2(n, color = rep("red", network.size(n) - 1))
+    Condition
+      Error in `set_node()`:
+      ! incorrect node.color length
+
+---
+
+    Code
+      ggnet2(n, edge.color = NA)
+    Condition
+      Error in `set_edge()`:
+      ! incorrect edge.color value
+
+---
+
+    Code
+      ggnet2(n, edge.color = -1)
+    Condition
+      Error in `set_edge()`:
+      ! incorrect edge.color value
+
+---
+
+    Code
+      ggnet2(n, edge.color = rep("red", network.edgecount(n) - 1))
+    Condition
+      Error in `set_edge()`:
+      ! incorrect edge.color length
+
+---
+
+    Code
+      ggnet2(n, mode = c("xx", "yy"))
+    Condition
+      Error in `set_attr()`:
+      ! vertex attribute xx was not found
+
+---
+
+    Code
+      ggnet2(n, mode = c("phono", "phono"))
+    Condition
+      Error in `set_attr()`:
+      ! vertex attribute phono is not numeric
+
+---
+
+    Code
+      ggnet2(n, mode = matrix(1, ncol = 2, nrow = 9))
+    Condition
+      Error in `set_attr()`:
+      ! incorrect coordinates length
+
+---
+
+    Code
+      ggnet2(n, arrow.size = -1)
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `arrow.size` value
+
+---
+
+    Code
+      ggnet(n, arrow.size = 12, arrow.gap = -1)
+    Condition
+      Warning:
+      `ggnet()` was deprecated in GGally 2.2.2.
+      i Please use `ggnet2()` instead.
+      Warning:
+      network is undirected; `arrow.size` ignored
+      Error in `ggnet()`:
+      ! incorrect `arrow.gap` value
+
+---
+
+    Code
+      ggnet2(n, max_size = NA)
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `max_size` value
+
+---
+
+    Code
+      ggnet2(n, na.rm = 1:2)
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `na.rm` value
+
+---
+
+    Code
+      ggnet2(n, na.rm = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! vertex attribute xyz was not found
+
+---
+
+    Code
+      ggnet2(n, size = "degree", size.min = -1)
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `size.min` value
+
+---
+
+    Code
+      ggnet2(n, size = "degree", size.max = -1)
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `size.max` value
+
+---
+
+    Code
+      ggnet2(n, size = 1:10, size.cut = NA)
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `size.cut` value
+
+---
+
+    Code
+      ggnet2(n, size = 1:10, size.cut = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `size.cut` value
+
+---
+
+    Code
+      ggnet2(n, alpha = "phono", alpha.palette = c(vowel = 1))
+    Condition
+      Error in `ggnet2()`:
+      ! no `alpha.palette` value for consonant
+
+---
+
+    Code
+      ggnet2(n, color = factor(1:10), palette = "Set1")
+    Condition
+      Error in `ggnet2()`:
+      ! too many node groups (10) for ColorBrewer palette Set1 (max: 9)
+
+---
+
+    Code
+      ggnet2(n, color = "phono", color.palette = c(vowel = 1))
+    Condition
+      Error in `ggnet2()`:
+      ! no `color.palette` value for consonant
+
+---
+
+    Code
+      ggnet2(n, shape = "phono", shape.palette = c(vowel = 1))
+    Condition
+      Error in `ggnet2()`:
+      ! no `shape.palette` value for consonant
+
+---
+
+    Code
+      ggnet2(n, size = "phono", size.palette = c(vowel = 1))
+    Condition
+      Error in `ggnet2()`:
+      ! no `size.palette` value for consonant
+
+---
+
+    Code
+      ggnet2(n, label = TRUE, label.alpha = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `label.alpha` value
+
+---
+
+    Code
+      ggnet2(n, label = TRUE, label.color = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `label.color` value
+
+---
+
+    Code
+      ggnet2(n, label = TRUE, label.size = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `label.size` value
+
+---
+
+    Code
+      ggnet2(n, label = TRUE, label.trim = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `label.trim` value
+
+---
+
+    Code
+      ggnet2(n, mode = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! unsupported placement method: `gplot.layout.xyz`
+
+---
+
+    Code
+      ggnet2(n, mode = letters[1:3])
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `mode` value
+
+---
+
+    Code
+      ggnet2(n, edge.color = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `edge.color` value
+
+---
+
+    Code
+      ggnet2(n, edge.label = "xyz", edge.label.alpha = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `edge.label.alpha` value
+
+---
+
+    Code
+      ggnet2(n, edge.label = "xyz", edge.label.color = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `edge.label.color` value
+
+---
+
+    Code
+      ggnet2(n, edge.label = "xyz", edge.label.size = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `edge.label.size` value
+
+---
+
+    Code
+      ggnet2(n, edge.size = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `edge.size` value
+
+---
+
+    Code
+      ggnet2(n, layout.exp = "xyz")
+    Condition
+      Error in `ggnet2()`:
+      ! incorrect `layout.exp` value
+
+---
+
+    Code
+      ggnet2(1:2)
+    Condition
+      Error in `ggnet2()`:
+      ! could not coerce `net` to a network object
+
+---
+
+    Code
+      ggnet2(network(data.frame(1:2, 3:4), hyper = TRUE))
+    Condition
+      Error:
+      ! If `hyper` is `TRUE`, the first two columns of `x` should be list columns.
+
+---
+
+    Code
+      ggnet2(network(data.frame(1:2, 3:4), multiple = TRUE))
+    Condition
+      Error in `ggnet2()`:
+      ! `ggnet2()` cannot plot multiplex graphs
+

--- a/tests/testthat/_snaps/ggnetworkmap.md
+++ b/tests/testthat/_snaps/ggnetworkmap.md
@@ -1,0 +1,40 @@
+# labels
+
+    Code
+      ggnetworkmap(usa, flights, label.nodes = c("A", "B"))
+    Condition
+      Error in `ggnetworkmap()`:
+      ! length(labels) == nrow(plotcord) is not TRUE
+
+# arrow.size
+
+    Code
+      ggnetworkmap(net = flights, arrow.size = -1)
+    Condition
+      Error in `ggnetworkmap()`:
+      ! incorrect `arrow.size` value
+
+# network coercion
+
+    Code
+      ggnetworkmap(net = 1:2)
+    Condition
+      Error in `ggnetworkmap()`:
+      ! could not coerce `net` to a network object
+
+---
+
+    Code
+      ggnetworkmap(net = network(data.frame(1:2, 3:4), hyper = TRUE))
+    Condition
+      Error:
+      ! If `hyper` is `TRUE`, the first two columns of `x` should be list columns.
+
+---
+
+    Code
+      ggnetworkmap(net = network(data.frame(1:2, 3:4), multiple = TRUE))
+    Condition
+      Error in `ggnetworkmap()`:
+      ! `ggnetworkmap()` cannot plot multiplex graphs
+

--- a/tests/testthat/_snaps/ggnostic.md
+++ b/tests/testthat/_snaps/ggnostic.md
@@ -1,0 +1,17 @@
+# fn_switch
+
+    Code
+      fn(dummy_dt, ggplot2::aes(value = !!as.name("B")))
+    Condition
+      Error in `fn()`:
+      ! function could not be found for `value` or `default`. Please include one of these two keys as a function.
+
+# error checking
+
+    Code
+      get_cols(c("not_there", ".fitted", ".se.fit", ".resid", ".std.resid", ".sigma",
+        ".hat", ".cooksd"))
+    Condition
+      Error in `match_nostic_columns()`:
+      ! Could not match `columnsY`: "not_there" to choices: "mpg", ".fitted", ".se.fit", ".resid", ".hat", ".sigma", ".cooksd", and ".std.resid"
+

--- a/tests/testthat/_snaps/ggparcoord.md
+++ b/tests/testthat/_snaps/ggparcoord.md
@@ -1,0 +1,166 @@
+# stops
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = NULL,
+      order = "anyClass")
+    Condition
+      Error in `ggparcoord()`:
+      ! can't use the `order` methods "anyClass" or "allClass" without specifying groupColumn
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = NULL,
+      order = "allClass")
+    Condition
+      Error in `ggparcoord()`:
+      ! can't use the `order` methods "anyClass" or "allClass" without specifying groupColumn
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = c(1, 2))
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `groupColumn`; must be a single numeric or character index
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 0+1i)
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `groupColumn`; must be a single numeric or character index
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2, scale = "notValid")
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `scale`; must be one of "std", "robust", "uniminmax", "globalminmax", "center", or "centerObs".
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      centerObsID = nrow(diamonds.samp) + 10)
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `centerObsID`; must be a single numeric row index
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      missing = "notValid")
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `missing`; must be one of "exclude", "mean", "median", "min10", "random".
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2, order = "notValid")
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `order`
+      i must either be a vector of column indices or one of `skewness`, `allClass`, `anyClass`, `Outlying`, `Skewed`, `Clumpy`, `Sparse`, `Striated`, `Convex`, `Skinny`, `Stringy`, or `Monotonic`
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2, order = 0+1i)
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `order`
+      i must either be a vector of column indices or one of `skewness`, `allClass`, `anyClass`, `Outlying`, `Skewed`, `Clumpy`, `Sparse`, `Striated`, `Convex`, `Skinny`, `Stringy`, or `Monotonic`
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      showPoints = 1)
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `showPoints`; must be a logical operator
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      alphaLines = "notAColumn")
+    Condition
+      Error in `ggparcoord()`:
+      ! `alphaLines` column is missing in data
+
+---
+
+    Code
+      ggparcoord(data = tmpDt, columns = c(1, 5:10), groupColumn = 2, alphaLines = "price")
+    Condition
+      Error in `ggparcoord()`:
+      ! missing data in `alphaLines` column
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      alphaLines = "price")
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `alphaLines` column; max range must be from 0 to 1
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      alphaLines = -0.1)
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `alphaLines`; must be a scalar value between 0 and 1
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      alphaLines = 1.1)
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `alphaLines`; must be a scalar value between 0 and 1
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      boxplot = 1)
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `boxplot`; must be a logical operator
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      shadeBox = c(1, 2))
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `shadeBox`; must be a single color
+
+---
+
+    Code
+      ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 2,
+      shadeBox = "notacolor")
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `shadeBox`; must be a valid R color
+
+---
+
+    Code
+      ggparcoord(diamonds.samp, columns = c(1, 5:10), groupColumn = 2, splineFactor = NULL)
+    Condition
+      Error in `ggparcoord()`:
+      ! invalid value for `splineFactor`; must be a logical or numeric value
+

--- a/tests/testthat/_snaps/ggscatmat.md
+++ b/tests/testthat/_snaps/ggscatmat.md
@@ -1,0 +1,24 @@
+# stops
+
+    Code
+      ggscatmat(flea, columns = c(1, 2))
+    Condition
+      Error in `ggscatmat()`:
+      ! Not enough numeric variables to make a scatter plot matrix
+
+---
+
+    Code
+      ggscatmat(flea, columns = c(1, 1, 1))
+    Condition
+      Error in `ggscatmat()`:
+      ! All of your variables are factors. Need numeric variables to make scatter plot matrix.
+
+---
+
+    Code
+      scatmat(flea, columns = c(1, 1, 1))
+    Condition
+      Error in `scatmat()`:
+      ! All of your variables are factors. Need numeric variables to make scatterplot matrix.
+

--- a/tests/testthat/_snaps/ggsurv.md
+++ b/tests/testthat/_snaps/ggsurv.md
@@ -1,0 +1,48 @@
+# stops
+
+    Code
+      ggsurv(lungNoCensor, surv.col = c("black", "red"))
+    Condition
+      Error in `ggsurv()`:
+      ! length(surv.col) == 1 | length(surv.col) == strata is not TRUE
+
+---
+
+    Code
+      ggsurv(lungNoCensor, lty.est = 1:2)
+    Condition
+      Error in `ggsurv()`:
+      ! length(lty.est) == 1 | length(lty.est) == strata is not TRUE
+
+---
+
+    Code
+      ggsurv(lungNoCensor, plot.cens = TRUE)
+    Condition
+      Error in `fn()`:
+      ! There are no censored observations
+
+---
+
+    Code
+      ggsurv(kidneyNoCensor, surv.col = c("black", "red", "blue"))
+    Condition
+      Error in `ggsurv()`:
+      ! length(surv.col) == 1 | length(surv.col) == strata is not TRUE
+
+---
+
+    Code
+      ggsurv(kidneyNoCensor, lty.est = 1:3)
+    Condition
+      Error in `ggsurv()`:
+      ! length(lty.est) == 1 | length(lty.est) == strata is not TRUE
+
+---
+
+    Code
+      ggsurv(kidneyNoCensor, plot.cens = TRUE)
+    Condition
+      Error in `fn()`:
+      ! There are no censored observations
+

--- a/tests/testthat/_snaps/wrap.md
+++ b/tests/testthat/_snaps/wrap.md
@@ -1,0 +1,64 @@
+# errors
+
+    Code
+      wrap(fn, NA)
+    Condition
+      Error in `wrap()`:
+      ! all parameters must be named arguments
+
+---
+
+    Code
+      wrap(fn, y = TRUE, 5)
+    Condition
+      Error in `wrap()`:
+      ! all parameters must be named arguments
+
+---
+
+    Code
+      wrapp(fn, list(5))
+    Condition
+      Error in `wrapp()`:
+      ! `params` must be a named list, named vector, or "NULL".
+
+---
+
+    Code
+      wrapp(fn, table(1:10, 1:10))
+    Condition
+      Error in `wrapp()`:
+      ! `params` must be a named list, named vector, or "NULL".
+
+---
+
+    Code
+      wrapp(fn, list(A = 4, 5))
+    Condition
+      Error in `wrapp()`:
+      ! `params` must be a named list, named vector, or "NULL".
+
+---
+
+    Code
+      wrap("does not exist", A = 5)
+    Condition
+      Error in `value[[3L]]()`:
+      ! Error retrieving `GGally` function.
+      Please provide a string such as "points" for `ggally_points()`
+      For a list of all predefined functions, check out `vig_ggally("ggally_plots")`
+      A custom function may be supplied directly: `wrap(my_fn, param = val)`
+      Function provided: `does not exist()`
+
+---
+
+    Code
+      wrapp("does not exist", list(A = 5))
+    Condition
+      Error in `value[[3L]]()`:
+      ! Error retrieving `GGally` function.
+      Please provide a string such as "points" for `ggally_points()`
+      For a list of all predefined functions, check out `vig_ggally("ggally_plots")`
+      A custom function may be supplied directly: `wrap(my_fn, param = val)`
+      Function provided: `does not exist()`
+

--- a/tests/testthat/_snaps/zzz_ggpairs.md
+++ b/tests/testthat/_snaps/zzz_ggpairs.md
@@ -1,0 +1,227 @@
+# stops
+
+    Code
+      ggpairs(tips, columns = c("tip", "day", "not in tips"))
+    Condition
+      Error in `fix_column_values()`:
+      ! Columns in `columns` not found in data: `'not in tips'`.
+      i Choices: `total_bill`, `tip`, `sex`, `smoker`, `day`, `time`, and `size`
+
+---
+
+    Code
+      ggduo(tips, columnsX = c("tip", "day", "not in tips"), columnsY = "smoker")
+    Condition
+      Error in `fix_column_values()`:
+      ! Columns in `columnsX` not found in data: `'not in tips'`.
+      i Choices: `total_bill`, `tip`, `sex`, `smoker`, `day`, `time`, and `size`
+
+---
+
+    Code
+      ggduo(tips, columnsX = c("tip", "day", "smoker"), columnsY = "not in tips")
+    Condition
+      Error in `fix_column_values()`:
+      ! Columns in `columnsY` not found in data: `'not in tips'`.
+      i Choices: `total_bill`, `tip`, `sex`, `smoker`, `day`, `time`, and `size`
+
+---
+
+    Code
+      ggpairs(tips, columns = 1:10)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columns" values are less than or equal to 7.
+      * columns = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+
+---
+
+    Code
+      ggduo(tips, columnsX = 1:10)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columnsX" values are less than or equal to 7.
+      * columnsX = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+
+---
+
+    Code
+      ggduo(tips, columnsY = 1:10)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columnsY" values are less than or equal to 7.
+      * columnsY = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+
+---
+
+    Code
+      ggpairs(tips, columns = -5:5)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columns" values are positive.
+      * columnsName = c(-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5)
+
+---
+
+    Code
+      ggduo(tips, columnsX = -5:5)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columnsX" values are positive.
+      * columnsName = c(-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5)
+
+---
+
+    Code
+      ggduo(tips, columnsY = -5:5)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columnsY" values are positive.
+      * columnsName = c(-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5)
+
+---
+
+    Code
+      ggpairs(tips, columns = (2:10) / 2)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columns" values are integers.
+      * columnsName = c(toString(columns))
+
+---
+
+    Code
+      ggduo(tips, columnsX = (2:10) / 2)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columnsX" values are integers.
+      * columnsName = c(toString(columns))
+
+---
+
+    Code
+      ggduo(tips, columnsY = (2:10) / 2)
+    Condition
+      Error in `fix_column_values()`:
+      ! Make sure your numeric "columnsY" values are integers.
+      * columnsName = c(toString(columns))
+
+---
+
+    Code
+      ggpairs(tips, columns = 1:3, columnLabels = c("A", "B", "C", "Extra"))
+    Condition
+      Error in `fix_column_values()`:
+      ! The length of the `columnLabels` does not match the length of the `columns` being used.
+      * Labels: c(A, B, C, Extra)
+      * Columns: c(1, 2, 3)
+
+---
+
+    Code
+      ggduo(tips, columnsX = 1:3, columnLabelsX = c("A", "B", "C", "Extra"))
+    Condition
+      Error in `fix_column_values()`:
+      ! The length of the `columnLabelsX` does not match the length of the `columnsX` being used.
+      * Labels: c(A, B, C, Extra)
+      * Columns: c(1, 2, 3)
+
+---
+
+    Code
+      ggduo(tips, columnsY = 1:3, columnLabelsY = c("A", "B", "C", "Extra"))
+    Condition
+      Error in `fix_column_values()`:
+      ! The length of the `columnLabelsY` does not match the length of the `columnsY` being used.
+      * Labels: c(A, B, C, Extra)
+      * Columns: c(1, 2, 3)
+
+---
+
+    Code
+      ggpairs(tips, upper = c("not_a_list"))
+    Condition
+      Error in `check_and_set_ggpairs_defaults()`:
+      ! `upper` is not a list
+
+---
+
+    Code
+      ggpairs(tips, diag = c("not_a_list"))
+    Condition
+      Error in `check_and_set_ggpairs_defaults()`:
+      ! `diag` is not a list
+
+---
+
+    Code
+      ggpairs(tips, lower = c("not_a_list"))
+    Condition
+      Error in `check_and_set_ggpairs_defaults()`:
+      ! `lower` is not a list
+
+---
+
+    Code
+      ggduo(tips, types = c("not_a_list"))
+    Condition
+      Error in `check_and_set_ggpairs_defaults()`:
+      ! `types` is not a list
+
+---
+
+    Code
+      ggpairs(tips, upper = list(aes_string = ggplot2::aes(color = .data$day)))
+    Condition
+      Error in `check_and_set_ggpairs_defaults()`:
+      ! `aes_string()` is a deprecated element for the section upper. Please use 'mapping' instead.
+
+---
+
+    Code
+      ggpairs(tips, lower = list(aes_string = ggplot2::aes(color = .data$day)))
+    Condition
+      Error in `check_and_set_ggpairs_defaults()`:
+      ! `aes_string()` is a deprecated element for the section lower. Please use 'mapping' instead.
+
+---
+
+    Code
+      ggpairs(tips, diag = list(aes_string = ggplot2::aes(color = .data$day)))
+    Condition
+      Error in `check_and_set_ggpairs_defaults()`:
+      ! `aes_string()` is a deprecated element for the section diag. Please use 'mapping' instead.
+
+---
+
+    Code
+      ggduo(tips, types = list(aes_string = ggplot2::aes(color = .data$day)))
+    Condition
+      Error in `check_and_set_ggpairs_defaults()`:
+      ! `aes_string()` is a deprecated element for the section types. Please use 'mapping' instead.
+
+# cardinality
+
+    Code
+      stop_if_high_cardinality(tips, 1:ncol(tips), "not numeric")
+    Condition
+      Error in `stop_if_high_cardinality()`:
+      ! `cardinality_threshold` should be a numeric or `NULL`.
+
+---
+
+    Code
+      stop_if_high_cardinality(tips, 1:ncol(tips), 2)
+    Condition
+      Error in `stop_if_high_cardinality()`:
+      ! Column "day" has more levels (4) than the threshold (2) allowed.
+      i Please remove the column or increase the 'cardinality_threshold' parameter. Increasing the cardinality_threshold may produce long processing times.
+
+# mapping
+
+    Code
+      ggpairs(tips, columns = 1:3, mapping = 1:3)
+    Condition
+      Error in `stop_if_bad_mapping()`:
+      ! `mapping` should not be numeric unless 'columns' is missing from function call.
+

--- a/tests/testthat/test-crosstalk.R
+++ b/tests/testthat/test-crosstalk.R
@@ -9,46 +9,30 @@ test_that("crosstalk works with ggduo and ggpairs", {
   expect_silent({
     pm <- ggpairs(sd)
   })
-  expect_error(
-    {
-      pm <- ggpairs(sd, 3:5)
-    },
-    "Make sure your numeric"
-  )
-  expect_error(
-    {
-      pm <- ggpairs(sd, c("Petal.Length", "Petal.Width", crosstalk_key()))
-    },
-    "Columns in `columns` not"
+  expect_snapshot(ggpairs(sd, 3:5), error = TRUE)
+  expect_snapshot(
+    ggpairs(sd, c("Petal.Length", "Petal.Width", crosstalk_key())),
+    error = TRUE
   )
 
   expect_silent({
     pm <- ggduo(sd)
   })
-  expect_error(
-    {
-      pm <- ggduo(sd, c(1:2, 5), 3:5)
-    },
-    "Make sure your numeric"
+  expect_snapshot(ggduo(sd, c(1:2, 5), 3:5), error = TRUE)
+  expect_snapshot(
+    ggduo(
+      sd,
+      c("Sepal.Length", "Sepal.Width", crosstalk_key()),
+      c("Petal.Length", "Petal.Width")
+    ),
+    error = TRUE
   )
-  expect_error(
-    {
-      pm <- ggduo(
-        sd,
-        c("Sepal.Length", "Sepal.Width", crosstalk_key()),
-        c("Petal.Length", "Petal.Width")
-      )
-    },
-    "Columns in `columnsX` not"
-  )
-  expect_error(
-    {
-      pm <- ggduo(
-        sd,
-        c("Sepal.Length", "Sepal.Width"),
-        c("Petal.Length", "Petal.Width", crosstalk_key())
-      )
-    },
-    "Columns in `columnsY` not"
+  expect_snapshot(
+    ggduo(
+      sd,
+      c("Sepal.Length", "Sepal.Width"),
+      c("Petal.Length", "Petal.Width", crosstalk_key())
+    ),
+    error = TRUE
   )
 })

--- a/tests/testthat/test-gg-plots.R
+++ b/tests/testthat/test-gg-plots.R
@@ -90,12 +90,9 @@ test_that("cor", {
   expect_warn(ti2, "Removing 1 row that")
   expect_warn(ti3, "Removed 3 rows containing")
 
-  expect_error(
-    ggally_cor(
-      ti,
-      ggplot2::aes(x = total_bill, y = tip, color = size)
-    ),
-    "must be categorical"
+  expect_snapshot(
+    ggally_cor(ti, ggplot2::aes(x = total_bill, y = tip, color = size)),
+    error = TRUE
   )
   expect_silent(
     ggally_cor(
@@ -154,11 +151,9 @@ test_that("diagAxis", {
   )
   expect_equal(pDat2, testDt2)
 
-  expect_error(
-    {
-      ggally_diagAxis(iris, mapping = ggplot2::aes(y = Sepal.Length))
-    },
-    "mapping\\$x is null."
+  expect_snapshot(
+    ggally_diagAxis(iris, mapping = ggplot2::aes(y = Sepal.Length)),
+    error = TRUE
   )
 })
 

--- a/tests/testthat/test-ggcorr.R
+++ b/tests/testthat/test-ggcorr.R
@@ -82,7 +82,7 @@ test_that("further options", {
     "geom-tile-no-limits",
     ggcorr(flea[, -1], geom = "tile", limits = FALSE)
   )
-  expect_error(ggcorr(flea[, -1], layout.exp = "a"), "incorrect `layout.exp`")
+  expect_snapshot(ggcorr(flea[, -1], layout.exp = "a"), error = TRUE)
   ggally_expect_doppelganger("layout.exp", ggcorr(flea[, -1], layout.exp = 1))
 })
 
@@ -98,7 +98,7 @@ test_that("cor_matrix", {
 })
 
 test_that("other geoms", {
-  expect_error(ggcorr(flea[, -1], geom = "hexbin"), "incorrect geom")
+  expect_snapshot(ggcorr(flea[, -1], geom = "hexbin"), error = TRUE)
   ggally_expect_doppelganger(
     "geom-blank",
     ggcorr(flea[, -1], geom = "blank")

--- a/tests/testthat/test-ggmatrix.R
+++ b/tests/testthat/test-ggmatrix.R
@@ -1,28 +1,27 @@
 data(tips)
 
 test_that("stops", {
-  expect_error(
+  expect_snapshot(
     ggmatrix(plots = matrix(), nrow = 2, ncol = 3),
-    "`plots` must be a `list()`",
-    fixed = TRUE
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggmatrix(plots = list(), nrow = "2", ncol = 3),
-    "`nrow` must be a numeric value"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggmatrix(plots = list(), nrow = 2, ncol = "3"),
-    "`ncol` must be a numeric value"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggmatrix(plots = list(), nrow = c(2, 3), ncol = 3),
-    "`nrow` must be a single numeric value"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggmatrix(plots = list(), nrow = 2, ncol = c(2, 3)),
-    "`ncol` must be a single numeric value"
+    error = TRUE
   )
 })
 
@@ -34,9 +33,9 @@ test_that("expression labels", {
   p <- ggpairs(tips, 1:2, columnLabels = exprs, labeller = "label_parsed")
   ggally_expect_doppelganger("expression-labels", p)
 
-  expect_error(
+  expect_snapshot(
     print(ggpairs(tips, 1:2, columnLabels = expression(alpha, beta))),
-    "xAxisLabels"
+    error = TRUE
   )
 })
 
@@ -133,11 +132,11 @@ test_that("blank", {
 
   expect_equal(length(pm$plots), 4)
 
-  expect_error(
+  expect_snapshot(
     {
       pm[2, 2] <- "not blank"
     },
-    "character values \\(besides `'blank'`\\)"
+    error = TRUE
   )
 })
 
@@ -185,23 +184,17 @@ test_that("ggmatrix_gtable progress", {
 #
 
 test_that("ggmatrix proportions", {
-  expect_error(
-    {
-      ggmatrix_proportions("not auto", tips, 1:ncol(tips))
-    },
-    "need to be non-NA"
+  expect_snapshot(
+    ggmatrix_proportions("not auto", tips, 1:ncol(tips)),
+    error = TRUE
   )
-  expect_error(
-    {
-      ggmatrix_proportions(NA, tips, 1:ncol(tips))
-    },
-    "need to be non-NA"
+  expect_snapshot(
+    ggmatrix_proportions(NA, tips, 1:ncol(tips)),
+    error = TRUE
   )
-  expect_error(
-    {
-      ggmatrix_proportions(c(1, NA, 1, 1, 1, 1, 1), tips, 1:ncol(tips))
-    },
-    "need to be non-NA"
+  expect_snapshot(
+    ggmatrix_proportions(c(1, NA, 1, 1, 1, 1, 1), tips, 1:ncol(tips)),
+    error = TRUE
   )
 
   expect_equal(

--- a/tests/testthat/test-ggmatrix_add.R
+++ b/tests/testthat/test-ggmatrix_add.R
@@ -22,7 +22,7 @@ test_that("add", {
   expect_true(!is.null(pm3$gg))
 
   # bad add
-  expect_error(pm + 3, "`ggmatrix()` does not know how to add", fixed = TRUE)
+  expect_snapshot(pm + 3, error = TRUE)
 
   # adding scale
   pm4 <- pm + ggplot2::scale_fill_brewer()

--- a/tests/testthat/test-ggmatrix_getput.R
+++ b/tests/testthat/test-ggmatrix_getput.R
@@ -3,16 +3,16 @@ data(tips)
 test_that("stops", {
   pm <- ggpairs(tips)
   p <- ggally_blankDiag()
-  expect_error(pm["total_bill", 1], "`i` may only be a single")
-  expect_error(pm[1, "total_bill"], "`j` may only be a single")
-  expect_error(pm["total_bill", 1] <- p, "`i` may only be a single")
-  expect_error(pm[1, "total_bill"] <- p, "`j` may only be a single")
+  expect_snapshot(pm["total_bill", 1], error = TRUE)
+  expect_snapshot(pm[1, "total_bill"], error = TRUE)
+  expect_snapshot(pm["total_bill", 1] <- p, error = TRUE)
+  expect_snapshot(pm[1, "total_bill"] <- p, error = TRUE)
 
   pm <- ggduo(tips, 1:3, 1:4)
-  expect_error(pm[0, 1], "`i` may only be in the range")
-  expect_error(pm[1, 0], "`j` may only be in the range")
-  expect_error(pm[5, 1], "`i` may only be in the range")
-  expect_error(pm[1, 4], "`j` may only be in the range")
+  expect_snapshot(pm[0, 1], error = TRUE)
+  expect_snapshot(pm[1, 0], error = TRUE)
+  expect_snapshot(pm[5, 1], error = TRUE)
+  expect_snapshot(pm[1, 4], error = TRUE)
 
   for (i in 1:4) {
     for (j in 1:3) {
@@ -37,12 +37,7 @@ test_that("get", {
 
   # test odd input and retrieve it
   a[2, 1] <- 1:4
-  expect_error(
-    {
-      a[2, 1]
-    },
-    "unknown plot object type"
-  )
+  expect_snapshot(a[2, 1], error = TRUE)
 })
 
 test_that("put", {

--- a/tests/testthat/test-ggmatrix_location.R
+++ b/tests/testthat/test-ggmatrix_location.R
@@ -37,14 +37,8 @@ test_that("rows work", {
     cols = 1:7
   )
 
-  expect_error(
-    ggmatrix_location(pm, rows = TRUE),
-    "numeric"
-  )
-  expect_error(
-    ggmatrix_location(pm, rows = "1"),
-    "numeric"
-  )
+  expect_snapshot(ggmatrix_location(pm, rows = TRUE), error = TRUE)
+  expect_snapshot(ggmatrix_location(pm, rows = "1"), error = TRUE)
 })
 
 
@@ -62,14 +56,8 @@ test_that("cols work", {
     cols = 1
   )
 
-  expect_error(
-    ggmatrix_location(pm, cols = TRUE),
-    "numeric"
-  )
-  expect_error(
-    ggmatrix_location(pm, cols = "1"),
-    "numeric"
-  )
+  expect_snapshot(ggmatrix_location(pm, cols = TRUE), error = TRUE)
+  expect_snapshot(ggmatrix_location(pm, cols = "1"), error = TRUE)
 })
 
 
@@ -110,9 +98,7 @@ test_that("location character", {
     subset(to_loc, col == row)
   )
 
-  expect_error(
-    ggmatrix_location(pm, location = "unknown")
-  )
+  expect_snapshot(ggmatrix_location(pm, location = "unknown"), error = TRUE)
 })
 
 
@@ -143,18 +129,10 @@ test_that("location matrix", {
     subset(to_loc, FALSE)
   )
 
-  expect_error(
-    ggmatrix_location(pm, location = mat[, 1:6])
-  )
-  expect_error(
-    ggmatrix_location(pm, location = mat[1:6, ])
-  )
-  expect_error(
-    ggmatrix_location(pm, location = cbind(mat, 1))
-  )
-  expect_error(
-    ggmatrix_location(pm, location = rbind(mat, 1))
-  )
+  expect_snapshot(ggmatrix_location(pm, location = mat[, 1:6]), error = TRUE)
+  expect_snapshot(ggmatrix_location(pm, location = mat[1:6, ]), error = TRUE)
+  expect_snapshot(ggmatrix_location(pm, location = cbind(mat, 1)), error = TRUE)
+  expect_snapshot(ggmatrix_location(pm, location = rbind(mat, 1)), error = TRUE)
 })
 
 
@@ -167,25 +145,31 @@ test_that("location matrix", {
     expand.grid(row = 1:7, col = 1:7)
   )
 
-  expect_error(
-    ggmatrix_location(pm, location = expand.grid(row = 1:7, col = 2:8))
+  expect_snapshot(
+    ggmatrix_location(pm, location = expand.grid(row = 1:7, col = 2:8)),
+    error = TRUE
   )
-  expect_error(
-    ggmatrix_location(pm, location = expand.grid(row = 2:8, col = 1:7))
-  )
-
-  expect_error(
-    ggmatrix_location(pm, location = expand.grid(row = 1:7, col = 0:6))
-  )
-  expect_error(
-    ggmatrix_location(pm, location = expand.grid(row = 0:6, col = 1:7))
+  expect_snapshot(
+    ggmatrix_location(pm, location = expand.grid(row = 2:8, col = 1:7)),
+    error = TRUE
   )
 
-  expect_error(
-    ggmatrix_location(pm, location = expand.grid(row = 1:7, col = c(1:6, NA)))
+  expect_snapshot(
+    ggmatrix_location(pm, location = expand.grid(row = 1:7, col = 0:6)),
+    error = TRUE
   )
-  expect_error(
-    ggmatrix_location(pm, location = expand.grid(row = c(1:6, NA), col = 1:7))
+  expect_snapshot(
+    ggmatrix_location(pm, location = expand.grid(row = 0:6, col = 1:7)),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ggmatrix_location(pm, location = expand.grid(row = 1:7, col = c(1:6, NA))),
+    error = TRUE
+  )
+  expect_snapshot(
+    ggmatrix_location(pm, location = expand.grid(row = c(1:6, NA), col = 1:7)),
+    error = TRUE
   )
 })
 

--- a/tests/testthat/test-ggnet.R
+++ b/tests/testthat/test-ggnet.R
@@ -136,18 +136,18 @@ test_that("examples", {
 
   ### --- test errors in set_node
 
-  expect_error(ggnet(n, group = NA), "incorrect")
-  expect_error(ggnet(n, group = 1:3), "incorrect")
-  expect_error(ggnet(n, label = TRUE, label.size = -10:-1), "incorrect")
-  expect_error(ggnet(n, size = "phono"), "incorrect")
+  expect_snapshot(ggnet(n, group = NA), error = TRUE)
+  expect_snapshot(ggnet(n, group = 1:3), error = TRUE)
+  expect_snapshot(ggnet(n, label = TRUE, label.size = -10:-1), error = TRUE)
+  expect_snapshot(ggnet(n, size = "phono"), error = TRUE)
 
   ggnet(n, group = "weights")
 
   ### --- test errors in set_edges
 
-  expect_error(ggnet(n, segment.label = NA), "incorrect")
-  expect_error(ggnet(n, segment.label = 1:3), "incorrect")
-  expect_error(ggnet(n, segment.label = -11:-1), "incorrect") # unnecessary
+  expect_snapshot(ggnet(n, segment.label = NA), error = TRUE)
+  expect_snapshot(ggnet(n, segment.label = 1:3), error = TRUE)
+  expect_snapshot(ggnet(n, segment.label = -11:-1), error = TRUE) # unnecessary
   # expect_error(ggnet(n, size = "phono"), "incorrect")
 
   n %e% "weights" <- sample(1:2, network.edgecount(n), replace = TRUE)
@@ -158,24 +158,21 @@ test_that("examples", {
 
   ggnet(n, mode = matrix(1, ncol = 2, nrow = 10))
   ggnet(n, mode = c("lon", "lat"))
-  expect_error(ggnet(n, mode = c("xx", "yy")), "not found")
+  expect_snapshot(ggnet(n, mode = c("xx", "yy")), error = TRUE)
   n %v% "abc" <- "abc"
-  expect_error(ggnet(n, mode = c("abc", "abc")), "not numeric")
-  expect_error(
-    ggnet(n, mode = matrix(1, ncol = 2, nrow = 9)),
-    "coordinates length"
-  )
+  expect_snapshot(ggnet(n, mode = c("abc", "abc")), error = TRUE)
+  expect_snapshot(ggnet(n, mode = matrix(1, ncol = 2, nrow = 9)), error = TRUE)
 
   ### --- test arrow.size
 
-  expect_error(ggnet(n, arrow.size = -1), "incorrect `arrow.size`")
+  expect_snapshot(ggnet(n, arrow.size = -1), error = TRUE)
   expect_warning(ggnet(n, arrow.size = 1), "`arrow.size` ignored")
 
   ### --- test arrow.gap
 
-  suppressWarnings(expect_error(
+  suppressWarnings(expect_snapshot(
     ggnet(n, arrow.size = 12, arrow.gap = -1),
-    "incorrect `arrow.gap`"
+    error = TRUE
   ))
   suppressWarnings(expect_warning(
     ggnet(n, arrow.size = 12, arrow.gap = 0.1),
@@ -197,10 +194,7 @@ test_that("examples", {
 
   # test weight.min
   suppressMessages({
-    expect_error(
-      ggnet(n, weight = "degree", weight.min = -1),
-      "incorrect `weight.min`"
-    )
+    expect_snapshot(ggnet(n, weight = "degree", weight.min = -1), error = TRUE)
     expect_message(
       ggnet(n, weight = "degree", weight.min = 1),
       "`weight.min` removed"
@@ -212,10 +206,7 @@ test_that("examples", {
   })
 
   # test weight.max
-  expect_error(
-    ggnet(n, weight = "degree", weight.max = -1),
-    "incorrect `weight.max`"
-  )
+  expect_snapshot(ggnet(n, weight = "degree", weight.max = -1), error = TRUE)
   expect_message(
     ggnet(n, weight = "degree", weight.max = 99),
     "`weight.max` removed"
@@ -226,11 +217,11 @@ test_that("examples", {
       "removed all nodes"
     )
   })
-  expect_error(ggnet(n, weight = "abc"), "incorrect `weight.method`")
+  expect_snapshot(ggnet(n, weight = "abc"), error = TRUE)
 
   # test weight.cut
-  expect_error(ggnet(n, weight.cut = NA), "incorrect `weight.cut`")
-  expect_error(ggnet(n, weight.cut = "a"), "incorrect `weight.cut`")
+  expect_snapshot(ggnet(n, weight.cut = NA), error = TRUE)
+  expect_snapshot(ggnet(n, weight.cut = "a"), error = TRUE)
   expect_warning(ggnet(n, weight.cut = 3), "`weight.cut` ignored")
   ggnet(n, weight = "degree", weight.cut = 3)
 
@@ -242,26 +233,23 @@ test_that("examples", {
 
   ggnet(n, label = letters[1:10], color = "white")
   ggnet(n, label = "abc", color = "white", label.size = 4, size = 12)
-  expect_error(
+  expect_snapshot(
     ggnet(n, label = letters[1:10], label.size = "abc"),
-    "incorrect `label.size`"
+    error = TRUE
   )
 
   ### --- test node placement
 
-  expect_error(ggnet(n, mode = "xyz"), "unsupported")
-  expect_error(ggnet(n, mode = letters[1:3]), "incorrect `mode`")
+  expect_snapshot(ggnet(n, mode = "xyz"), error = TRUE)
+  expect_snapshot(ggnet(n, mode = letters[1:3]), error = TRUE)
 
   ### --- test label.trim
-  expect_error(
-    ggnet(n, label = TRUE, label.trim = "xyz"),
-    "incorrect `label.trim`"
-  )
+  expect_snapshot(ggnet(n, label = TRUE, label.trim = "xyz"), error = TRUE)
   ggnet(n, label = TRUE, color = "white", label.trim = 1)
   ggnet(n, label = TRUE, color = "white", label.trim = toupper)
 
   ### --- test layout.exp
-  expect_error(ggnet(n, layout.exp = "xyz"))
+  expect_snapshot(ggnet(n, layout.exp = "xyz"), error = TRUE)
   ggnet(n, layout.exp = 0.1)
 
   ### --- test bipartite functionality
@@ -292,11 +280,14 @@ test_that("examples", {
     "self-loops"
   )
 
-  expect_error(ggnet(1:2), "network object")
-  expect_error(ggnet(network(data.frame(1:2, 3:4), hyper = TRUE)), "hyper")
-  expect_error(
+  expect_snapshot(ggnet(1:2), error = TRUE)
+  expect_snapshot(
+    ggnet(network(data.frame(1:2, 3:4), hyper = TRUE)),
+    error = TRUE
+  )
+  expect_snapshot(
     ggnet(network(data.frame(1:2, 3:4), multiple = TRUE)),
-    "multiplex graphs"
+    error = TRUE
   )
 
   ### --- test igraph functionality

--- a/tests/testthat/test-ggnet2.R
+++ b/tests/testthat/test-ggnet2.R
@@ -66,17 +66,23 @@ test_that("examples", {
   ### --- end: documented examples
 
   # test node assignment errors
-  expect_error(ggnet2(n, color = NA))
-  expect_error(ggnet2(n, color = -1))
-  expect_error(ggnet2(n, color = rep("red", network.size(n) - 1)))
+  expect_snapshot(ggnet2(n, color = NA), error = TRUE)
+  expect_snapshot(ggnet2(n, color = -1), error = TRUE)
+  expect_snapshot(
+    ggnet2(n, color = rep("red", network.size(n) - 1)),
+    error = TRUE
+  )
 
   # test node assignment
   ggnet2(n, color = rep("red", network.size(n)))
 
   # test node assignment errors
-  expect_error(ggnet2(n, edge.color = NA))
-  expect_error(ggnet2(n, edge.color = -1))
-  expect_error(ggnet2(n, edge.color = rep("red", network.edgecount(n) - 1)))
+  expect_snapshot(ggnet2(n, edge.color = NA), error = TRUE)
+  expect_snapshot(ggnet2(n, edge.color = -1), error = TRUE)
+  expect_snapshot(
+    ggnet2(n, edge.color = rep("red", network.edgecount(n) - 1)),
+    error = TRUE
+  )
 
   # test edge assignment
   ggnet2(n, edge.color = rep("red", network.edgecount(n)))
@@ -87,22 +93,19 @@ test_that("examples", {
   n %v% "x" <- sample(1:10)
   n %v% "y" <- sample(1:10)
   ggnet2(n, mode = c("x", "y"))
-  expect_error(ggnet2(n, mode = c("xx", "yy")), "not found")
-  expect_error(ggnet2(n, mode = c("phono", "phono")), "not numeric")
-  expect_error(
-    ggnet2(n, mode = matrix(1, ncol = 2, nrow = 9)),
-    "coordinates length"
-  )
+  expect_snapshot(ggnet2(n, mode = c("xx", "yy")), error = TRUE)
+  expect_snapshot(ggnet2(n, mode = c("phono", "phono")), error = TRUE)
+  expect_snapshot(ggnet2(n, mode = matrix(1, ncol = 2, nrow = 9)), error = TRUE)
 
   # test arrow.size
-  expect_error(ggnet2(n, arrow.size = -1), "incorrect `arrow.size`")
+  expect_snapshot(ggnet2(n, arrow.size = -1), error = TRUE)
   expect_warning(ggnet2(n, arrow.size = 1), "`arrow.size` ignored")
 
   # test arrow.gap
 
-  suppressWarnings(expect_error(
+  suppressWarnings(expect_snapshot(
     ggnet(n, arrow.size = 12, arrow.gap = -1),
-    "incorrect `arrow.gap`"
+    error = TRUE
   ))
   suppressWarnings(expect_warning(
     ggnet(n, arrow.size = 12, arrow.gap = 0.1),
@@ -117,11 +120,11 @@ test_that("examples", {
   ggnet2(m, arrow.size = 12, arrow.gap = 0.05)
 
   # test max_size
-  expect_error(ggnet2(n, max_size = NA), "incorrect `max_size`")
+  expect_snapshot(ggnet2(n, max_size = NA), error = TRUE)
 
   # test na.rm
-  expect_error(ggnet2(n, na.rm = 1:2), "incorrect `na.rm`")
-  expect_error(ggnet2(n, na.rm = "xyz"), "not found")
+  expect_snapshot(ggnet2(n, na.rm = 1:2), error = TRUE)
+  expect_snapshot(ggnet2(n, na.rm = "xyz"), error = TRUE)
 
   n %v% "missing" <- ifelse(n %v% "phono" == "vowel", NA, n %v% "phono")
   expect_message(ggnet2(n, na.rm = "missing"), "removed")
@@ -135,10 +138,7 @@ test_that("examples", {
   ggnet2(n, size = "degree")
 
   # test size.min
-  expect_error(
-    ggnet2(n, size = "degree", size.min = -1),
-    "incorrect `size.min`"
-  )
+  expect_snapshot(ggnet2(n, size = "degree", size.min = -1), error = TRUE)
   expect_message(ggnet2(n, size = "degree", size.min = 1), "`size.min` removed")
   suppressMessages({
     expect_warning(ggnet2(n, size = "abc", size.min = 1), "not numeric")
@@ -146,10 +146,7 @@ test_that("examples", {
   })
 
   # test size.max
-  expect_error(
-    ggnet2(n, size = "degree", size.max = -1),
-    "incorrect `size.max`"
-  )
+  expect_snapshot(ggnet2(n, size = "degree", size.max = -1), error = TRUE)
   expect_message(
     ggnet2(n, size = "degree", size.max = 99),
     "`size.max` removed"
@@ -162,46 +159,46 @@ test_that("examples", {
   # test size.cut
   ggnet2(n, size = 1:10, size.cut = 3)
   ggnet2(n, size = 1:10, size.cut = TRUE)
-  expect_error(ggnet2(n, size = 1:10, size.cut = NA), "incorrect `size.cut`")
-  expect_error(ggnet2(n, size = 1:10, size.cut = "xyz"), "incorrect `size.cut`")
+  expect_snapshot(ggnet2(n, size = 1:10, size.cut = NA), error = TRUE)
+  expect_snapshot(ggnet2(n, size = 1:10, size.cut = "xyz"), error = TRUE)
   expect_warning(ggnet2(n, size = "abc", size.cut = 3), "not numeric")
   expect_warning(ggnet2(n, size = 1, size.cut = 3), "ignored")
 
   # test alpha.palette
   ggnet2(n, alpha = "phono", alpha.palette = c("vowel" = 1, "consonant" = 0.5))
   ggnet2(n, alpha = factor(1:10))
-  expect_error(
+  expect_snapshot(
     ggnet2(n, alpha = "phono", alpha.palette = c("vowel" = 1)),
-    "no `alpha.palette` value"
+    error = TRUE
   )
 
   # test color.palette
   # ggnet2(n, color = "phono", color.palette = c("vowel" = 1, "consonant" = 2))
   ggnet2(n, color = factor(1:10))
   ggnet2(n, color = "phono", palette = "Set1") # only 2 groups, palette has min. 3
-  expect_error(
+  expect_snapshot(
     ggnet2(n, color = factor(1:10), palette = "Set1"),
-    "too many node groups"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggnet2(n, color = "phono", color.palette = c("vowel" = 1)),
-    "no `color.palette` value"
+    error = TRUE
   )
 
   # test shape.palette
   ggnet2(n, shape = "phono", shape.palette = c("vowel" = 15, "consonant" = 19))
   expect_warning(ggnet2(n, shape = factor(1:10)), "discrete values")
-  expect_error(
+  expect_snapshot(
     ggnet2(n, shape = "phono", shape.palette = c("vowel" = 1)),
-    "no `shape.palette` value"
+    error = TRUE
   )
 
   # test size.palette
   ggnet2(n, size = "phono", size.palette = c("vowel" = 1, "consonant" = 2))
   ggnet2(n, size = factor(1:10))
-  expect_error(
+  expect_snapshot(
     ggnet2(n, size = "phono", size.palette = c("vowel" = 1)),
-    "no `size.palette` value"
+    error = TRUE
   )
 
   # test node.label
@@ -209,63 +206,51 @@ test_that("examples", {
   ggnet2(n, label = "phono")
 
   # test label.alpha
-  expect_error(
-    ggnet2(n, label = TRUE, label.alpha = "xyz"),
-    "incorrect `label.alpha`"
-  )
+  expect_snapshot(ggnet2(n, label = TRUE, label.alpha = "xyz"), error = TRUE)
 
   # test label.color
-  expect_error(
-    ggnet2(n, label = TRUE, label.color = "xyz"),
-    "incorrect `label.color`"
-  )
+  expect_snapshot(ggnet2(n, label = TRUE, label.color = "xyz"), error = TRUE)
 
   # test label.size
-  expect_error(
-    ggnet2(n, label = TRUE, label.size = "xyz"),
-    "incorrect `label.size`"
-  )
+  expect_snapshot(ggnet2(n, label = TRUE, label.size = "xyz"), error = TRUE)
 
   # test label.trim
-  expect_error(
-    ggnet2(n, label = TRUE, label.trim = "xyz"),
-    "incorrect `label.trim`"
-  )
+  expect_snapshot(ggnet2(n, label = TRUE, label.trim = "xyz"), error = TRUE)
   ggnet2(n, label = TRUE, label.trim = toupper)
 
   # test mode
-  expect_error(ggnet2(n, mode = "xyz"), "unsupported")
-  expect_error(ggnet2(n, mode = letters[1:3]), "incorrect `mode`")
+  expect_snapshot(ggnet2(n, mode = "xyz"), error = TRUE)
+  expect_snapshot(ggnet2(n, mode = letters[1:3]), error = TRUE)
 
   # test edge.node shared colors
   ggnet2(n, color = "phono", edge.color = c("color", "grey"))
 
   # test edge.color
-  expect_error(ggnet2(n, edge.color = "xyz"), "incorrect `edge.color`")
+  expect_snapshot(ggnet2(n, edge.color = "xyz"), error = TRUE)
 
   # test edge.label.alpha
-  expect_error(
+  expect_snapshot(
     ggnet2(n, edge.label = "xyz", edge.label.alpha = "xyz"),
-    "incorrect `edge.label.alpha`"
+    error = TRUE
   )
 
   # test edge.label.color
-  expect_error(
+  expect_snapshot(
     ggnet2(n, edge.label = "xyz", edge.label.color = "xyz"),
-    "incorrect `edge.label.color`"
+    error = TRUE
   )
 
   # test edge.label.size
-  expect_error(
+  expect_snapshot(
     ggnet2(n, edge.label = "xyz", edge.label.size = "xyz"),
-    "incorrect `edge.label.size`"
+    error = TRUE
   )
 
   # test edge.size
-  expect_error(ggnet2(n, edge.size = "xyz"), "incorrect `edge.size`")
+  expect_snapshot(ggnet2(n, edge.size = "xyz"), error = TRUE)
 
   # test layout.exp
-  expect_error(ggnet2(n, layout.exp = "xyz"))
+  expect_snapshot(ggnet2(n, layout.exp = "xyz"), error = TRUE)
   ggnet2(n, layout.exp = 0.1)
 
   ### --- test bipartite functionality
@@ -296,11 +281,14 @@ test_that("examples", {
     "self-loops"
   )
 
-  expect_error(ggnet2(1:2), "network object")
-  expect_error(ggnet2(network(data.frame(1:2, 3:4), hyper = TRUE)), "hyper")
-  expect_error(
+  expect_snapshot(ggnet2(1:2), error = TRUE)
+  expect_snapshot(
+    ggnet2(network(data.frame(1:2, 3:4), hyper = TRUE)),
+    error = TRUE
+  )
+  expect_snapshot(
     ggnet2(network(data.frame(1:2, 3:4), multiple = TRUE)),
-    "multiplex graphs"
+    error = TRUE
   )
 
   ### --- test igraph functionality

--- a/tests/testthat/test-ggnetworkmap.R
+++ b/tests/testthat/test-ggnetworkmap.R
@@ -259,7 +259,10 @@ test_that("arrows", {
 
 
 test_that("labels", {
-  expect_error(ggnetworkmap(usa, flights, label.nodes = c("A", "B")))
+  expect_snapshot(
+    ggnetworkmap(usa, flights, label.nodes = c("A", "B")),
+    error = TRUE
+  )
   testLabels <- paste("L", 1:network.size(flights), sep = "")
 
   # does logical check
@@ -281,10 +284,7 @@ test_that("labels", {
 ### --- test arrow.size
 
 test_that("arrow.size", {
-  expect_error(
-    ggnetworkmap(net = flights, arrow.size = -1),
-    "incorrect `arrow.size`"
-  )
+  expect_snapshot(ggnetworkmap(net = flights, arrow.size = -1), error = TRUE)
   expect_warning(
     ggnetworkmap(
       net = network(as.matrix(flights), directed = FALSE),
@@ -302,14 +302,14 @@ test_that("network coercion", {
     "self-loops"
   )
 
-  expect_error(ggnetworkmap(net = 1:2), "network object")
-  expect_error(
+  expect_snapshot(ggnetworkmap(net = 1:2), error = TRUE)
+  expect_snapshot(
     ggnetworkmap(net = network(data.frame(1:2, 3:4), hyper = TRUE)),
-    "hyper"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggnetworkmap(net = network(data.frame(1:2, 3:4), multiple = TRUE)),
-    "multiplex graphs"
+    error = TRUE
   )
 })
 

--- a/tests/testthat/test-ggnostic.R
+++ b/tests/testthat/test-ggnostic.R
@@ -29,9 +29,9 @@ test_that("fn_switch", {
 
   fn <- fn_switch(list(A = fn1), "value")
   expect_equal(fn(dummy_dt, ggplot2::aes(value = !!as.name("A"))), 1)
-  expect_error(
+  expect_snapshot(
     fn(dummy_dt, ggplot2::aes(value = !!as.name("B"))),
-    "function could not be found"
+    error = TRUE
   )
 })
 
@@ -95,7 +95,7 @@ test_that("error checking", {
     c(".resid", ".sigma", ".hat", ".cooksd")
   )
 
-  expect_error(
+  expect_snapshot(
     get_cols(c(
       "not_there",
       ".fitted",
@@ -106,6 +106,6 @@ test_that("error checking", {
       ".hat",
       ".cooksd"
     )),
-    "Could not match `columnsY`"
+    error = TRUE
   )
 })

--- a/tests/testthat/test-ggparcoord.R
+++ b/tests/testthat/test-ggparcoord.R
@@ -11,183 +11,183 @@ test_that("stops", {
   # basic parallel coordinate plot, using default settings
   # ggparcoord(data = diamonds.samp, columns = c(1, 5:10))
   # this time, color by diamond cut
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = NULL,
       order = "anyClass"
     ),
-    "can't use the `order` methods "
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = NULL,
       order = "allClass"
     ),
-    "can't use the `order` methods "
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = c(1, 2)
     ),
-    "invalid value for `groupColumn`"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggparcoord(data = diamonds.samp, columns = c(1, 5:10), groupColumn = 1i),
-    "invalid value for `groupColumn`"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       scale = "notValid"
     ),
-    "invalid value for `scale`"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       centerObsID = nrow(diamonds.samp) + 10
     ),
-    "invalid value for `centerObsID`"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       missing = "notValid"
     ),
-    "invalid value for `missing`"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       order = "notValid"
     ),
-    "invalid value for `order`"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       order = 1i
     ),
-    "invalid value for `order`"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       showPoints = 1
     ),
-    "invalid value for `showPoints`"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       alphaLines = "notAColumn"
     ),
-    "`alphaLines` column is missing in data"
+    error = TRUE
   )
   tmpDt <- diamonds.samp
   tmpDt$price[1] <- NA
   range(tmpDt$price)
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = tmpDt,
       columns = c(1, 5:10),
       groupColumn = 2,
       alphaLines = "price"
     ),
-    "missing data in `alphaLines` column"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       alphaLines = "price"
     ),
-    "invalid value for `alphaLines` column; max range "
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       alphaLines = -0.1
     ),
-    "invalid value for `alphaLines`; must be a scalar value"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       alphaLines = 1.1
     ),
-    "invalid value for `alphaLines`; must be a scalar value"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       boxplot = 1
     ),
-    "invalid value for `boxplot`"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       shadeBox = c(1, 2)
     ),
-    "invalid value for `shadeBox`; must be a single color"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       data = diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       shadeBox = "notacolor"
     ),
-    "invalid value for `shadeBox`; must be a valid R color"
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     ggparcoord(
       diamonds.samp,
       columns = c(1, 5:10),
       groupColumn = 2,
       splineFactor = NULL
     ),
-    "invalid value for `splineFactor`"
+    error = TRUE
   )
 })
 

--- a/tests/testthat/test-ggscatmat.R
+++ b/tests/testthat/test-ggscatmat.R
@@ -27,16 +27,7 @@ test_that("corMethod", {
 })
 
 test_that("stops", {
-  expect_error(
-    ggscatmat(flea, columns = c(1, 2)),
-    "Not enough numeric variables to"
-  )
-  expect_error(
-    ggscatmat(flea, columns = c(1, 1, 1)),
-    "All of your variables are factors"
-  )
-  expect_error(
-    scatmat(flea, columns = c(1, 1, 1)),
-    "All of your variables are factors"
-  )
+  expect_snapshot(ggscatmat(flea, columns = c(1, 2)), error = TRUE)
+  expect_snapshot(ggscatmat(flea, columns = c(1, 1, 1)), error = TRUE)
+  expect_snapshot(scatmat(flea, columns = c(1, 1, 1)), error = TRUE)
 })

--- a/tests/testthat/test-ggsurv.R
+++ b/tests/testthat/test-ggsurv.R
@@ -43,11 +43,14 @@ test_that("stops", {
   lungNoCensor <- survival::survfit(Surv(time, status) ~ 1, data = noCensor)
 
   # check that the surv.col and lty.est are of the correct length
-  expect_error(ggsurv(lungNoCensor, surv.col = c("black", "red")))
-  expect_error(ggsurv(lungNoCensor, lty.est = 1:2))
+  expect_snapshot(
+    ggsurv(lungNoCensor, surv.col = c("black", "red")),
+    error = TRUE
+  )
+  expect_snapshot(ggsurv(lungNoCensor, lty.est = 1:2), error = TRUE)
 
   # must have censor to plot
-  expect_error(ggsurv(lungNoCensor, plot.cens = TRUE))
+  expect_snapshot(ggsurv(lungNoCensor, plot.cens = TRUE), error = TRUE)
 
   noCensor <- subset(kidney, status == 1)
   kidneyNoCensor <- survival::survfit(
@@ -56,11 +59,14 @@ test_that("stops", {
   )
 
   # check that the surv.col and lty.est are of the correct length.  should be 4
-  expect_error(ggsurv(kidneyNoCensor, surv.col = c("black", "red", "blue")))
-  expect_error(ggsurv(kidneyNoCensor, lty.est = 1:3))
+  expect_snapshot(
+    ggsurv(kidneyNoCensor, surv.col = c("black", "red", "blue")),
+    error = TRUE
+  )
+  expect_snapshot(ggsurv(kidneyNoCensor, lty.est = 1:3), error = TRUE)
 
   # must have censor to plot
-  expect_error(ggsurv(kidneyNoCensor, plot.cens = TRUE))
+  expect_snapshot(ggsurv(kidneyNoCensor, plot.cens = TRUE), error = TRUE)
 
   # must have censor to plot
   expect_silent(

--- a/tests/testthat/test-wrap.R
+++ b/tests/testthat/test-wrap.R
@@ -2,17 +2,17 @@ test_that("errors", {
   fn <- ggally_points
 
   # named params
-  expect_error(wrap(fn, NA), "all parameters")
-  expect_error(wrap(fn, y = TRUE, 5), "all parameters")
+  expect_snapshot(wrap(fn, NA), error = TRUE)
+  expect_snapshot(wrap(fn, y = TRUE, 5), error = TRUE)
 
   # named params to wrapp
-  expect_error(wrapp(fn, list(5)), "`params` must")
-  expect_error(wrapp(fn, table(1:10, 1:10)), "`params` must")
-  expect_error(wrapp(fn, list(A = 4, 5)), "`params` must")
+  expect_snapshot(wrapp(fn, list(5)), error = TRUE)
+  expect_snapshot(wrapp(fn, table(1:10, 1:10)), error = TRUE)
+  expect_snapshot(wrapp(fn, list(A = 4, 5)), error = TRUE)
 
   # if the character fn doesn't exist
-  expect_error(wrap("does not exist", A = 5), "Function provided")
-  expect_error(wrapp("does not exist", list(A = 5)), "Function provided")
+  expect_snapshot(wrap("does not exist", A = 5), error = TRUE)
+  expect_snapshot(wrapp("does not exist", list(A = 5)), error = TRUE)
 })
 
 test_that("wrap", {

--- a/tests/testthat/test-zzz_ggpairs.R
+++ b/tests/testthat/test-zzz_ggpairs.R
@@ -160,31 +160,17 @@ test_that("stops", {
     "Setting:\n"
   )
 
-  expect_error(
-    {
-      ggpairs(tips, columns = c("tip", "day", "not in tips"))
-    },
-    "Columns in `columns` not found in data"
+  expect_snapshot(
+    ggpairs(tips, columns = c("tip", "day", "not in tips")),
+    error = TRUE
   )
-  expect_error(
-    {
-      ggduo(
-        tips,
-        columnsX = c("tip", "day", "not in tips"),
-        columnsY = "smoker"
-      )
-    },
-    "Columns in `columnsX` not found in data"
+  expect_snapshot(
+    ggduo(tips, columnsX = c("tip", "day", "not in tips"), columnsY = "smoker"),
+    error = TRUE
   )
-  expect_error(
-    {
-      ggduo(
-        tips,
-        columnsX = c("tip", "day", "smoker"),
-        columnsY = "not in tips"
-      )
-    },
-    "Columns in `columnsY` not found in data"
+  expect_snapshot(
+    ggduo(tips, columnsX = c("tip", "day", "smoker"), columnsY = "not in tips"),
+    error = TRUE
   )
 
   lifecycle::expect_deprecated(
@@ -199,106 +185,35 @@ test_that("stops", {
     }
   )
 
-  expect_error(
-    {
-      ggpairs(tips, columns = 1:10)
-    },
-    "Make sure your numeric "
+  expect_snapshot(ggpairs(tips, columns = 1:10), error = TRUE)
+  expect_snapshot(ggduo(tips, columnsX = 1:10), error = TRUE)
+  expect_snapshot(ggduo(tips, columnsY = 1:10), error = TRUE)
+
+  expect_snapshot(ggpairs(tips, columns = -5:5), error = TRUE)
+  expect_snapshot(ggduo(tips, columnsX = -5:5), error = TRUE)
+  expect_snapshot(ggduo(tips, columnsY = -5:5), error = TRUE)
+
+  expect_snapshot(ggpairs(tips, columns = (2:10) / 2), error = TRUE)
+  expect_snapshot(ggduo(tips, columnsX = (2:10) / 2), error = TRUE)
+  expect_snapshot(ggduo(tips, columnsY = (2:10) / 2), error = TRUE)
+
+  expect_snapshot(
+    ggpairs(tips, columns = 1:3, columnLabels = c("A", "B", "C", "Extra")),
+    error = TRUE
   )
-  expect_error(
-    {
-      ggduo(tips, columnsX = 1:10)
-    },
-    "Make sure your numeric "
+  expect_snapshot(
+    ggduo(tips, columnsX = 1:3, columnLabelsX = c("A", "B", "C", "Extra")),
+    error = TRUE
   )
-  expect_error(
-    {
-      ggduo(tips, columnsY = 1:10)
-    },
-    "Make sure your numeric "
+  expect_snapshot(
+    ggduo(tips, columnsY = 1:3, columnLabelsY = c("A", "B", "C", "Extra")),
+    error = TRUE
   )
 
-  expect_error(
-    {
-      ggpairs(tips, columns = -5:5)
-    },
-    "Make sure your numeric "
-  )
-  expect_error(
-    {
-      ggduo(tips, columnsX = -5:5)
-    },
-    "Make sure your numeric "
-  )
-  expect_error(
-    {
-      ggduo(tips, columnsY = -5:5)
-    },
-    "Make sure your numeric "
-  )
-
-  expect_error(
-    {
-      ggpairs(tips, columns = (2:10) / 2)
-    },
-    "Make sure your numeric "
-  )
-  expect_error(
-    {
-      ggduo(tips, columnsX = (2:10) / 2)
-    },
-    "Make sure your numeric "
-  )
-  expect_error(
-    {
-      ggduo(tips, columnsY = (2:10) / 2)
-    },
-    "Make sure your numeric "
-  )
-
-  expect_error(
-    {
-      ggpairs(tips, columns = 1:3, columnLabels = c("A", "B", "C", "Extra"))
-    },
-    "The length of the `columnLabels` does not match the length of the"
-  )
-  expect_error(
-    {
-      ggduo(tips, columnsX = 1:3, columnLabelsX = c("A", "B", "C", "Extra"))
-    },
-    "The length of the `columnLabelsX` does not match the length of the"
-  )
-  expect_error(
-    {
-      ggduo(tips, columnsY = 1:3, columnLabelsY = c("A", "B", "C", "Extra"))
-    },
-    "The length of the `columnLabelsY` does not match the length of the"
-  )
-
-  expect_error(
-    {
-      ggpairs(tips, upper = c("not_a_list"))
-    },
-    "`upper` is not a list"
-  )
-  expect_error(
-    {
-      ggpairs(tips, diag = c("not_a_list"))
-    },
-    "`diag` is not a list"
-  )
-  expect_error(
-    {
-      ggpairs(tips, lower = c("not_a_list"))
-    },
-    "`lower` is not a list"
-  )
-  expect_error(
-    {
-      ggduo(tips, types = c("not_a_list"))
-    },
-    "`types` is not a list"
-  )
+  expect_snapshot(ggpairs(tips, upper = c("not_a_list")), error = TRUE)
+  expect_snapshot(ggpairs(tips, diag = c("not_a_list")), error = TRUE)
+  expect_snapshot(ggpairs(tips, lower = c("not_a_list")), error = TRUE)
+  expect_snapshot(ggduo(tips, types = c("not_a_list")), error = TRUE)
 
   # # couldn't get correct error message
   # #  variables: 'colour' have non standard format: 'total_bill + tip'.
@@ -309,30 +224,21 @@ test_that("stops", {
   #   ggduo(tips, mapping = ggplot2::aes(color = total_bill + tip))
   # }, "variables\\: \"colour\" have non standard format")
 
-  errorString <- "`aes_string\\(\\)` is a deprecated element"
-  expect_error(
-    {
-      ggpairs(tips, upper = list(aes_string = ggplot2::aes(color = .data$day)))
-    },
-    errorString
+  expect_snapshot(
+    ggpairs(tips, upper = list(aes_string = ggplot2::aes(color = .data$day))),
+    error = TRUE
   )
-  expect_error(
-    {
-      ggpairs(tips, lower = list(aes_string = ggplot2::aes(color = .data$day)))
-    },
-    errorString
+  expect_snapshot(
+    ggpairs(tips, lower = list(aes_string = ggplot2::aes(color = .data$day))),
+    error = TRUE
   )
-  expect_error(
-    {
-      ggpairs(tips, diag = list(aes_string = ggplot2::aes(color = .data$day)))
-    },
-    errorString
+  expect_snapshot(
+    ggpairs(tips, diag = list(aes_string = ggplot2::aes(color = .data$day))),
+    error = TRUE
   )
-  expect_error(
-    {
-      ggduo(tips, types = list(aes_string = ggplot2::aes(color = .data$day)))
-    },
-    errorString
+  expect_snapshot(
+    ggduo(tips, types = list(aes_string = ggplot2::aes(color = .data$day))),
+    error = TRUE
   )
 
   expect_diag_warn <- function(key, value) {
@@ -365,13 +271,13 @@ test_that("stops", {
 test_that("cardinality", {
   expect_silent(stop_if_high_cardinality(tips, 1:ncol(tips), NULL))
   expect_silent(stop_if_high_cardinality(tips, 1:ncol(tips), FALSE))
-  expect_error(
+  expect_snapshot(
     stop_if_high_cardinality(tips, 1:ncol(tips), "not numeric"),
-    "`cardinality_threshold` should"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     stop_if_high_cardinality(tips, 1:ncol(tips), 2),
-    "Column"
+    error = TRUE
   )
 })
 
@@ -564,12 +470,7 @@ test_that("mapping", {
   pm <- ggpairs(tips, columns = 1:3)
   expect_equal(pm$xAxisLabels, names(tips)[1:3])
 
-  expect_error(
-    {
-      ggpairs(tips, columns = 1:3, mapping = 1:3)
-    },
-    "`mapping` should not be numeric"
-  )
+  expect_snapshot(ggpairs(tips, columns = 1:3, mapping = 1:3), error = TRUE)
 })
 
 test_that("user functions", {
@@ -955,15 +856,16 @@ for (fn_info in list(
 test_that("bad types", {
   skip_on_cran()
 
-  expect_error({
+  expect_snapshot(
     ggpairs(
       tips,
       1:2,
       lower = "blank",
       diag = "blank",
       upper = list(continuous = "BAD_TYPE")
-    )
-  })
+    ),
+    error = TRUE
+  )
 })
 
 # pm <- ggpairs(tips, upper = "blank")


### PR DESCRIPTION
Replace `expect_error()` with `expect_snapshot()`. Replaced basically all, might be overkill/undesirable for some not using cli errors, but should be basically all of them. 